### PR TITLE
feat: increase secret range to 16 bits (1-65535)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build circuit
+        run: bun run build
+
+      - name: Run tests
+        run: bun run test

--- a/circuits/guess.circom
+++ b/circuits/guess.circom
@@ -7,22 +7,35 @@ template GuessNumber() {
     signal input number;
     signal input salt;
     signal input guess;
-    
+    signal input maxNumber; // Creator-defined max (1-65535)
+
     signal output commitment;
     signal output isCorrect;
-    
-    // Range constraints: ensure number is between 1 and 65535
+
+    // Range constraints: ensure number is between 1 and maxNumber
     // Check number >= 1
     component geq1 = GreaterEqThan(16); // 16 bits for numbers up to 65535
     geq1.in[0] <== number;
     geq1.in[1] <== 1;
     geq1.out === 1;
 
-    // Check number <= 65535
+    // Check number <= maxNumber (creator's custom range)
+    component leqMax = LessEqThan(16);
+    leqMax.in[0] <== number;
+    leqMax.in[1] <== maxNumber;
+    leqMax.out === 1;
+
+    // Check maxNumber <= 65535 (enforce upper bound)
     component leq65535 = LessEqThan(16);
-    leq65535.in[0] <== number;
+    leq65535.in[0] <== maxNumber;
     leq65535.in[1] <== 65535;
     leq65535.out === 1;
+
+    // Check maxNumber >= 1 (enforce lower bound)
+    component maxGeq1 = GreaterEqThan(16);
+    maxGeq1.in[0] <== maxNumber;
+    maxGeq1.in[1] <== 1;
+    maxGeq1.out === 1;
     
     // Generate commitment using Poseidon hash
     component hasher = Poseidon(2);
@@ -37,4 +50,4 @@ template GuessNumber() {
     isCorrect <== eq.out;
 }
 
-component main {public [guess]} = GuessNumber();
+component main {public [guess, maxNumber]} = GuessNumber();

--- a/circuits/guess.circom
+++ b/circuits/guess.circom
@@ -11,18 +11,18 @@ template GuessNumber() {
     signal output commitment;
     signal output isCorrect;
     
-    // Range constraints: ensure number is between 1 and 100
+    // Range constraints: ensure number is between 1 and 65535
     // Check number >= 1
-    component geq1 = GreaterEqThan(8); // 8 bits is enough for numbers up to 255
+    component geq1 = GreaterEqThan(16); // 16 bits for numbers up to 65535
     geq1.in[0] <== number;
     geq1.in[1] <== 1;
     geq1.out === 1;
-    
-    // Check number <= 100
-    component leq100 = LessEqThan(8);
-    leq100.in[0] <== number;
-    leq100.in[1] <== 100;
-    leq100.out === 1;
+
+    // Check number <= 65535
+    component leq65535 = LessEqThan(16);
+    leq65535.in[0] <== number;
+    leq65535.in[1] <== 65535;
+    leq65535.out === 1;
     
     // Generate commitment using Poseidon hash
     component hasher = Poseidon(2);

--- a/scripts/compile.ts
+++ b/scripts/compile.ts
@@ -18,7 +18,7 @@ async function compile() {
   
   try {
     // Compile circuit
-    const compileCmd = `npx circom2 ${circuitPath} --r1cs --wasm --sym -o ${outputDir}`;
+    const compileCmd = `npx circom2 "${circuitPath}" --r1cs --wasm --sym -o "${outputDir}"`;
     console.log(`Running: ${compileCmd}`);
     
     const { stdout, stderr } = await execAsync(compileCmd);

--- a/scripts/copy-artifacts.sh
+++ b/scripts/copy-artifacts.sh
@@ -21,4 +21,8 @@ cp "$CIRCUITS_DIR/circuits/guess.circom" "$CONTRACTS_DIR/circuits/guess.circom"
 # Copy verifier contract
 cp "$CIRCUITS_DIR/generated/GuessVerifier.sol" "$CONTRACTS_DIR/src/generated/GuessVerifier.sol"
 
+# Copy wasm and zkey for FFI proof generation in tests
+cp "$CIRCUITS_DIR/generated/guess_js/guess.wasm" "$CONTRACTS_DIR/circuits/guess.wasm"
+cp "$CIRCUITS_DIR/generated/guess_final.zkey" "$CONTRACTS_DIR/circuits/guess_final.zkey"
+
 echo "✓ Copied artifacts to contracts repo"

--- a/scripts/export-verifier.ts
+++ b/scripts/export-verifier.ts
@@ -34,7 +34,8 @@ async function exportVerifier() {
     // Read and display contract size
     const stats = await fs.stat(verifierPath);
     console.log(`  - Size: ${(stats.size / 1024).toFixed(2)} KB`);
-    
+
+    process.exit(0);
   } catch (error) {
     console.error("Failed to export verifier:", (error as Error).message);
     process.exit(1);

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -28,7 +28,7 @@ async function downloadPtau() {
     for (const url of urls) {
       try {
         console.log(`Trying ${url}...`);
-        await execAsync(`curl -L ${url} -o ${ptauPath}`);
+        await execAsync(`curl -L "${url}" -o "${ptauPath}"`);
         // Check if file is valid (should be > 1MB)
         const stats = await fs.stat(ptauPath);
         if (stats.size > 1000000) {

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -100,7 +100,8 @@ async function setup() {
     console.log("\n✅ Setup complete!");
     console.log(`  - Final zkey: ${zkeyFinalPath}`);
     console.log(`  - Verification key: ${vKeyPath}`);
-    
+
+    process.exit(0);
   } catch (error) {
     console.error("Setup failed:", (error as Error).message);
     process.exit(1);

--- a/test/guess.test.ts
+++ b/test/guess.test.ts
@@ -13,7 +13,8 @@ describe("GuessNumber Circuit", () => {
     const inputs: CircuitInputs = {
       number: "42",
       salt: "12345",
-      guess: "50"
+      guess: "50",
+      maxNumber: "100"
     };
 
     const { publicSignals } = await generateProof(
@@ -34,7 +35,8 @@ describe("GuessNumber Circuit", () => {
     const inputs: CircuitInputs = {
       number: "42",
       salt: "12345",
-      guess: "42"
+      guess: "42",
+      maxNumber: "100"
     };
 
     const { publicSignals } = await generateProof(
@@ -55,7 +57,8 @@ describe("GuessNumber Circuit", () => {
     const inputs: CircuitInputs = {
       number: "42",
       salt: "12345",
-      guess: "42"
+      guess: "42",
+      maxNumber: "100"
     };
 
     const { proof, publicSignals } = await generateProof(
@@ -77,13 +80,15 @@ describe("GuessNumber Circuit", () => {
     const inputs1: CircuitInputs = {
       number: "42",
       salt: "12345",
-      guess: "42"
+      guess: "42",
+      maxNumber: "100"
     };
 
     const inputs2: CircuitInputs = {
       number: "42",
       salt: "54321",
-      guess: "42"
+      guess: "42",
+      maxNumber: "100"
     };
 
     const { publicSignals: signals1 } = await generateProof(
@@ -106,24 +111,14 @@ describe("GuessNumber Circuit", () => {
     expect(signals2[1]).toBe("1");
   });
 
-  it("should enforce range constraints (1-65535)", async () => {
+  it("should enforce number >= 1", async () => {
     // Test number = 0 (should fail)
     await expect(generateProof(
       {
         number: "0",
         salt: "12345",
-        guess: "0"
-      },
-      circuitPaths.wasmPath,
-      circuitPaths.zkeyPath
-    )).rejects.toThrow();
-
-    // Test number = 65536 (should fail)
-    await expect(generateProof(
-      {
-        number: "65536",
-        salt: "12345",
-        guess: "65536"
+        guess: "0",
+        maxNumber: "100"
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
@@ -134,41 +129,110 @@ describe("GuessNumber Circuit", () => {
       {
         number: "1",
         salt: "12345",
-        guess: "1"
+        guess: "1",
+        maxNumber: "100"
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
     expect(signals1[1]).toBe("1"); // Correct guess
+  });
 
-    // Test number = 65535 (should pass)
-    const { publicSignals: signals65535 } = await generateProof(
+  it("should enforce number <= maxNumber", async () => {
+    // Test number > maxNumber (should fail)
+    await expect(generateProof(
       {
-        number: "65535",
+        number: "101",
         salt: "12345",
-        guess: "65535"
+        guess: "101",
+        maxNumber: "100"
+      },
+      circuitPaths.wasmPath,
+      circuitPaths.zkeyPath
+    )).rejects.toThrow();
+
+    // Test number = maxNumber (should pass)
+    const { publicSignals } = await generateProof(
+      {
+        number: "100",
+        salt: "12345",
+        guess: "100",
+        maxNumber: "100"
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
-    expect(signals65535[1]).toBe("1"); // Correct guess
+    expect(publicSignals[1]).toBe("1"); // Correct guess
+  });
+
+  it("should enforce maxNumber <= 65535", async () => {
+    // Test maxNumber > 65535 (should fail)
+    await expect(generateProof(
+      {
+        number: "100",
+        salt: "12345",
+        guess: "100",
+        maxNumber: "65536"
+      },
+      circuitPaths.wasmPath,
+      circuitPaths.zkeyPath
+    )).rejects.toThrow();
+
+    // Test maxNumber = 65535 (should pass)
+    const { publicSignals } = await generateProof(
+      {
+        number: "65535",
+        salt: "12345",
+        guess: "65535",
+        maxNumber: "65535"
+      },
+      circuitPaths.wasmPath,
+      circuitPaths.zkeyPath
+    );
+    expect(publicSignals[1]).toBe("1"); // Correct guess
+  });
+
+  it("should enforce maxNumber >= 1", async () => {
+    // Test maxNumber = 0 (should fail)
+    await expect(generateProof(
+      {
+        number: "1",
+        salt: "12345",
+        guess: "1",
+        maxNumber: "0"
+      },
+      circuitPaths.wasmPath,
+      circuitPaths.zkeyPath
+    )).rejects.toThrow();
   });
 
   // Proofs must be distinguishable by public signals so the contract knows which proof is for which guess
   it("should produce different public signals for different guesses", async () => {
     const proofA = await generateProof(
-      { number: "42", salt: "12345", guess: "42" },
+      { number: "42", salt: "12345", guess: "42", maxNumber: "100" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
 
     const proofB = await generateProof(
-      { number: "42", salt: "12345", guess: "99" },
+      { number: "42", salt: "12345", guess: "99", maxNumber: "100" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
 
     expect(proofA.proof).not.toEqual(proofB.proof);
     expect(proofA.publicSignals).not.toEqual(proofB.publicSignals);
+  });
+
+  it("should include maxNumber in public signals", async () => {
+    const { publicSignals } = await generateProof(
+      { number: "42", salt: "12345", guess: "42", maxNumber: "100" },
+      circuitPaths.wasmPath,
+      circuitPaths.zkeyPath
+    );
+
+    // Public signals: [commitment, isCorrect, guess, maxNumber]
+    expect(publicSignals[2]).toBe("42"); // guess
+    expect(publicSignals[3]).toBe("100"); // maxNumber
   });
 });

--- a/test/guess.test.ts
+++ b/test/guess.test.ts
@@ -106,7 +106,7 @@ describe("GuessNumber Circuit", () => {
     expect(signals2[1]).toBe("1");
   });
 
-  it("should enforce range constraints (1-100)", async () => {
+  it("should enforce range constraints (1-65535)", async () => {
     // Test number = 0 (should fail)
     await expect(generateProof(
       {
@@ -118,12 +118,12 @@ describe("GuessNumber Circuit", () => {
       circuitPaths.zkeyPath
     )).rejects.toThrow();
 
-    // Test number = 101 (should fail)
+    // Test number = 65536 (should fail)
     await expect(generateProof(
       {
-        number: "101",
+        number: "65536",
         salt: "12345",
-        guess: "101"
+        guess: "65536"
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
@@ -141,17 +141,17 @@ describe("GuessNumber Circuit", () => {
     );
     expect(signals1[1]).toBe("1"); // Correct guess
 
-    // Test number = 100 (should pass)
-    const { publicSignals: signals100 } = await generateProof(
+    // Test number = 65535 (should pass)
+    const { publicSignals: signals65535 } = await generateProof(
       {
-        number: "100",
+        number: "65535",
         salt: "12345",
-        guess: "100"
+        guess: "65535"
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
-    expect(signals100[1]).toBe("1"); // Correct guess
+    expect(signals65535[1]).toBe("1"); // Correct guess
   });
 
   // Proofs must be distinguishable by public signals so the contract knows which proof is for which guess

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -9,6 +9,7 @@ export interface CircuitInputs {
   number: string;
   salt: string;
   guess: string;
+  maxNumber: string;
 }
 
 export interface ProofResult {


### PR DESCRIPTION
## Summary
- Increase circuit range constraints from 8-bit (1-100) to 16-bit (1-65535)
- Add `maxNumber` as public input for creator-defined custom range
- Add `process.exit(0)` to setup and export-verifier scripts to fix hanging issue
- Update copy-artifacts script to also copy wasm and zkey files
- Update tests for new range and maxNumber constraints

Closes #6
Closes #8