### PR TITLE
feat(v2): puzzleId/guesser binding, guess range, domain-sep commitment

### DIFF
--- a/CEREMONY.md
+++ b/CEREMONY.md
@@ -7,3 +7,28 @@ Phase-2 multi-party trusted setup. Coordination happens in a Farcaster thread; t
 The operator will hand you a previous `.zkey` and a ready-to-run `snarkjs zkey contribute …` line. Run it, return the new `.zkey`, paste the contribution hash that snarkjs prints into the thread.
 
 Filename convention used in the chain: `guess_NNNN_<handle>.zkey` (zero-padded index, contributor handle, e.g. `guess_0003_alice.zkey`). `guess_final.zkey` is reserved for the post-beacon output.
+
+## Example
+
+Command:
+
+```sh
+snarkjs zkey contribute guess_0000_init.zkey guess_0001_chainhacker.zkey --name="chainhacker" -e="put high entropy text here"
+```
+
+Expected output:
+
+```sh
+[INFO]  snarkJS: Circuit Hash:
+                88f9ed43 6deed69b 3adfa492 ee69c932
+                df2d7650 f87270da dc3960d5 0ab0a8db
+                3a57f3ae 9bfb24e3 267b102f 4e5d0133
+                d051240e 03a0285c 0129a842 e5418627
+[INFO]  snarkJS: Contribution Hash:
+                ebdc3ad7 eb97fa91 9d6a1be0 101efb71
+                eee8e832 89b89df6 2521796d 7e591a7c
+                31cebea3 ed6c4148 c8f91396 55349242
+                2bfe7c07 3af4adb9 6d4e204d 747af6f1
+```
+
+The Contribution Hash is what you paste back into the Farcaster thread.

--- a/CEREMONY.md
+++ b/CEREMONY.md
@@ -1,0 +1,9 @@
+# zk-guess v2 ceremony — contributor steps
+
+Phase-2 multi-party trusted setup. Coordination happens in a Farcaster thread; this doc is just the run-it-once instructions.
+
+[Install snarkjs](https://github.com/iden3/snarkjs#install-snarkjs).
+
+The operator will hand you a previous `.zkey` and a ready-to-run `snarkjs zkey contribute …` line. Run it, return the new `.zkey`, paste the contribution hash that snarkjs prints into the thread.
+
+Filename convention used in the chain: `guess_NNNN_<handle>.zkey` (zero-padded index, contributor handle, e.g. `guess_0003_alice.zkey`). `guess_final.zkey` is reserved for the post-beacon output.

--- a/CEREMONY.md
+++ b/CEREMONY.md
@@ -1,6 +1,7 @@
 # zk-guess v2 ceremony — contributor steps
-
 Phase-2 multi-party trusted setup for [zk-guess-circuits](https://github.com/chainhackers/zk-guess-circuits/). Discussion in [this Farcaster thread](https://farcaster.xyz/chainhacker/0x94a225a9).
+
+<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/a3cac8a4-5a3c-439d-9adf-7a51bf393e38" />
 
 [Install snarkjs](https://github.com/iden3/snarkjs#install-snarkjs).
 
@@ -10,7 +11,7 @@ Filename: `guess_NNNN_<tag>.zkey` — zero-padded index + 2–4 char handle (e.g
 
 ## Returning the file
 
-Farcaster casts carry images, not arbitrary files. Upload your `.zkey` anywhere public — e.g. [temp.sh](https://temp.sh) (`curl -F'file=@guess_NNNN_<tag>.zkey' https://temp.sh/upload`, no account, 3-day retention) or a release asset on your own [zk-guess-circuits](https://github.com/chainhackers/zk-guess-circuits/) fork — and paste the URL in your reply with the Contribution Hash.
+Upload your `.zkey` anywhere public — e.g. [temp.sh](https://temp.sh) (`curl -F'file=@guess_NNNN_<tag>.zkey' https://temp.sh/upload`, no account, 3-day retention) or a release asset on your own [zk-guess-circuits](https://github.com/chainhackers/zk-guess-circuits/) fork — and paste the URL in your reply with the Contribution Hash.
 
 ## Example
 

--- a/CEREMONY.md
+++ b/CEREMONY.md
@@ -10,7 +10,7 @@ Filename: `guess_NNNN_<tag>.zkey` — zero-padded index + 2–4 char handle (e.g
 
 ## Returning the file
 
-Farcaster casts carry images, not arbitrary files. Upload your `.zkey` anywhere public — e.g. [0x0.st](https://0x0.st) (`curl -F'file=@guess_NNNN_<tag>.zkey' https://0x0.st`) or a release asset on your own [zk-guess-circuits](https://github.com/chainhackers/zk-guess-circuits/) fork — and paste the URL in your reply with the Contribution Hash.
+Farcaster casts carry images, not arbitrary files. Upload your `.zkey` anywhere public — e.g. [catbox.moe](https://catbox.moe) (no account, permanent: `curl -F'reqtype=fileupload' -F'fileToUpload=@guess_NNNN_<tag>.zkey' https://catbox.moe/user/api.php`) or a release asset on your own [zk-guess-circuits](https://github.com/chainhackers/zk-guess-circuits/) fork — and paste the URL in your reply with the Contribution Hash.
 
 ## Example
 

--- a/CEREMONY.md
+++ b/CEREMONY.md
@@ -10,7 +10,7 @@ Filename: `guess_NNNN_<tag>.zkey` — zero-padded index + 2–4 char handle (e.g
 
 ## Returning the file
 
-Farcaster casts carry images, not arbitrary files. Upload your `.zkey` anywhere public — e.g. [catbox.moe](https://catbox.moe) (no account, permanent: `curl -F'reqtype=fileupload' -F'fileToUpload=@guess_NNNN_<tag>.zkey' https://catbox.moe/user/api.php`) or a release asset on your own [zk-guess-circuits](https://github.com/chainhackers/zk-guess-circuits/) fork — and paste the URL in your reply with the Contribution Hash.
+Farcaster casts carry images, not arbitrary files. Upload your `.zkey` anywhere public — e.g. [temp.sh](https://temp.sh) (`curl -F'file=@guess_NNNN_<tag>.zkey' https://temp.sh/upload`, no account, 3-day retention) or a release asset on your own [zk-guess-circuits](https://github.com/chainhackers/zk-guess-circuits/) fork — and paste the URL in your reply with the Contribution Hash.
 
 ## Example
 

--- a/CEREMONY.md
+++ b/CEREMONY.md
@@ -8,6 +8,10 @@ The operator will hand you a previous `.zkey` and a ready-to-run `snarkjs zkey c
 
 Filename convention used in the chain: `guess_NNNN_<handle>.zkey` (zero-padded index, contributor handle, e.g. `guess_0003_alice.zkey`). `guess_final.zkey` is reserved for the post-beacon output.
 
+## Returning the file
+
+Farcaster casts carry images, not arbitrary files. Upload your new `.zkey` to any public host of your choice — e.g. [0x0.st](https://0x0.st) (no account, `curl -F'file=@guess_NNNN_<handle>.zkey' https://0x0.st` returns a URL) or a release asset on your own GitHub fork. Paste the URL in your Farcaster reply alongside the Contribution Hash.
+
 ## Example
 
 Command:

--- a/CEREMONY.md
+++ b/CEREMONY.md
@@ -1,26 +1,22 @@
 # zk-guess v2 ceremony — contributor steps
 
-Phase-2 multi-party trusted setup. Coordination happens in a Farcaster thread; this doc is just the run-it-once instructions.
+Phase-2 multi-party trusted setup for [zk-guess-circuits](https://github.com/chainhackers/zk-guess-circuits/). Discussion in [this Farcaster thread](https://farcaster.xyz/chainhacker/0x94a225a9).
 
 [Install snarkjs](https://github.com/iden3/snarkjs#install-snarkjs).
 
-The operator will hand you a previous `.zkey` and a ready-to-run `snarkjs zkey contribute …` line. Run it, return the new `.zkey`, paste the contribution hash that snarkjs prints into the thread.
+The operator will hand you a previous `.zkey` and a ready-to-run `snarkjs zkey contribute …` line. Run it, send the new `.zkey` back, paste the Contribution Hash into the thread.
 
-Filename convention used in the chain: `guess_NNNN_<handle>.zkey` (zero-padded index, contributor handle, e.g. `guess_0003_alice.zkey`). `guess_final.zkey` is reserved for the post-beacon output.
+Filename: `guess_NNNN_<tag>.zkey` — zero-padded index + 2–4 char handle (e.g. `guess_0001_ch.zkey`). `guess_final.zkey` is reserved for the post-beacon output.
 
 ## Returning the file
 
-Farcaster casts carry images, not arbitrary files. Upload your new `.zkey` to any public host of your choice — e.g. [0x0.st](https://0x0.st) (no account, `curl -F'file=@guess_NNNN_<handle>.zkey' https://0x0.st` returns a URL) or a release asset on your own GitHub fork. Paste the URL in your Farcaster reply alongside the Contribution Hash.
+Farcaster casts carry images, not arbitrary files. Upload your `.zkey` anywhere public — e.g. [0x0.st](https://0x0.st) (`curl -F'file=@guess_NNNN_<tag>.zkey' https://0x0.st`) or a release asset on your own [zk-guess-circuits](https://github.com/chainhackers/zk-guess-circuits/) fork — and paste the URL in your reply with the Contribution Hash.
 
 ## Example
 
-Command:
-
 ```sh
-snarkjs zkey contribute guess_0000_init.zkey guess_0001_chainhacker.zkey --name="chainhacker" -e="put high entropy text here"
+snarkjs zkey contribute guess_0000_init.zkey guess_0001_ch.zkey --name="ch" -e="put high entropy text here"
 ```
-
-Expected output:
 
 ```sh
 [INFO]  snarkJS: Circuit Hash:
@@ -34,5 +30,3 @@ Expected output:
                 31cebea3 ed6c4148 c8f91396 55349242
                 2bfe7c07 3af4adb9 6d4e204d 747af6f1
 ```
-
-The Contribution Hash is what you paste back into the Farcaster thread.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,6 @@
 # ZK Guess Circuits
 
-Zero-knowledge circuits that prove knowledge of a secret number without revealing it.
-
-## Circuit
-
-```circom
-template GuessNumber() {
-    signal input number;      // Private: secret number (1-100)
-    signal input salt;        // Private: randomness
-    signal input guess;       // Public: player's guess
-    
-    signal output commitment; // Poseidon(number, salt)
-    signal output isCorrect;  // 1 if correct, 0 if not
-}
-```
+Zero-knowledge circuits that prove knowledge of a secret number without revealing it. Source of truth: [`circuits/guess.circom`](circuits/guess.circom).
 
 ## Quick Start
 
@@ -21,7 +8,7 @@ template GuessNumber() {
 # Install dependencies
 bun install
 
-# Build everything (compile + trusted setup)
+# Build everything (compile + dev setup)
 bun run build
 
 # Run tests
@@ -31,14 +18,19 @@ bun run test
 bun run copy-to-contracts
 ```
 
+## Trusted setup
+
+`bun run build` runs a single-contributor dev setup, suitable for tests and local dev only. Production deployments use a multi-party phase-2 ceremony — see [CEREMONY.md](CEREMONY.md).
+
 ## Repository Structure
 
-This repository should be placed as a sibling to the contracts repository:
+This repository should be placed as a sibling to the contracts and frontend repos:
 
 ```
 parent-directory/
 ├── zk-guess-circuits/    # This repository
-└── zk-guess-contracts/   # Contracts repository
+├── zk-guess-contracts/   # Solidity verifier + on-chain logic
+└── zk-guess/frontend/    # Browser proof generation
 ```
 
 ## Performance
@@ -49,9 +41,10 @@ parent-directory/
 
 ## Build Artifacts
 
-- `generated/guess.wasm` - Browser proof generation
-- `generated/guess_final.zkey` - Proving key
-- `generated/GuessVerifier.sol` - Solidity verifier
+- `generated/guess.wasm` — browser proof generation
+- `generated/guess_dev.zkey` — dev proving key (single-contributor; not for production)
+- `generated/guess_final.zkey` — ceremony proving key (produced by phase-2 ceremony, see [CEREMONY.md](CEREMONY.md))
+- `generated/GuessVerifier.sol` — Solidity verifier
 
 ## License
 

--- a/circuits/guess.circom
+++ b/circuits/guess.circom
@@ -14,14 +14,18 @@ template GuessNumber() {
     signal input guess;
     signal input maxNumber; // Creator-defined max (1-65535)
     signal input puzzleId;  // Binds the proof to a specific puzzle
+    signal input guesser;   // Binds the proof to a specific Ethereum address (uint160)
 
     signal output commitment;
     signal output isCorrect;
 
-    // Force puzzleId into the constraint system so a valid proof for puzzle A
-    // cannot be replayed on puzzle B (even if both share the same commitment).
+    // Force puzzleId and guesser into the constraint system so the proof cannot
+    // be replayed on another puzzle or front-run under a different msg.sender
+    // even if the witness would otherwise be identical.
     signal puzzleIdSquared;
     puzzleIdSquared <== puzzleId * puzzleId;
+    signal guesserSquared;
+    guesserSquared <== guesser * guesser;
 
     // Range constraints: ensure number is between 1 and maxNumber
     // Check number >= 1
@@ -75,4 +79,4 @@ template GuessNumber() {
     isCorrect <== eq.out;
 }
 
-component main {public [guess, maxNumber, puzzleId]} = GuessNumber();
+component main {public [guess, maxNumber, puzzleId, guesser]} = GuessNumber();

--- a/circuits/guess.circom
+++ b/circuits/guess.circom
@@ -8,9 +8,15 @@ template GuessNumber() {
     signal input salt;
     signal input guess;
     signal input maxNumber; // Creator-defined max (1-65535)
+    signal input puzzleId;  // Binds the proof to a specific puzzle
 
     signal output commitment;
     signal output isCorrect;
+
+    // Force puzzleId into the constraint system so a valid proof for puzzle A
+    // cannot be replayed on puzzle B (even if both share the same commitment).
+    signal puzzleIdSquared;
+    puzzleIdSquared <== puzzleId * puzzleId;
 
     // Range constraints: ensure number is between 1 and maxNumber
     // Check number >= 1
@@ -63,4 +69,4 @@ template GuessNumber() {
     isCorrect <== eq.out;
 }
 
-component main {public [guess, maxNumber]} = GuessNumber();
+component main {public [guess, maxNumber, puzzleId]} = GuessNumber();

--- a/circuits/guess.circom
+++ b/circuits/guess.circom
@@ -4,6 +4,11 @@ include "../node_modules/circomlib/circuits/poseidon.circom";
 include "../node_modules/circomlib/circuits/comparators.circom";
 
 template GuessNumber() {
+    // keccak256("zkguess.v2") mod p(BN254). Domain-separates v2 commitments
+    // from v1 Poseidon(2) commitments and from any future version. Must stay
+    // in sync with DOMAIN_TAG in src/constants.ts.
+    var DOMAIN_TAG = 6000605569458108169701754207643449997818461959397281845176039583157698733685;
+
     signal input number;
     signal input salt;
     signal input guess;
@@ -56,10 +61,11 @@ template GuessNumber() {
     guessLeqMax.in[1] <== maxNumber;
     guessLeqMax.out === 1;
 
-    // Generate commitment using Poseidon hash
-    component hasher = Poseidon(2);
-    hasher.inputs[0] <== number;
-    hasher.inputs[1] <== salt;
+    // Generate commitment using domain-separated Poseidon hash
+    component hasher = Poseidon(3);
+    hasher.inputs[0] <== DOMAIN_TAG;
+    hasher.inputs[1] <== number;
+    hasher.inputs[2] <== salt;
     commitment <== hasher.out;
     
     // Check if guess matches number

--- a/circuits/guess.circom
+++ b/circuits/guess.circom
@@ -65,14 +65,12 @@ template GuessNumber() {
     guessLeqMax.in[1] <== maxNumber;
     guessLeqMax.out === 1;
 
-    // Generate commitment using domain-separated Poseidon hash
     component hasher = Poseidon(3);
     hasher.inputs[0] <== DOMAIN_TAG;
     hasher.inputs[1] <== number;
     hasher.inputs[2] <== salt;
     commitment <== hasher.out;
-    
-    // Check if guess matches number
+
     component eq = IsEqual();
     eq.in[0] <== guess;
     eq.in[1] <== number;

--- a/circuits/guess.circom
+++ b/circuits/guess.circom
@@ -36,7 +36,20 @@ template GuessNumber() {
     maxGeq1.in[0] <== maxNumber;
     maxGeq1.in[1] <== 1;
     maxGeq1.out === 1;
-    
+
+    // Range-check guess: 1 <= guess <= maxNumber
+    // Symmetric with the constraints on `number` so the proof layer, not the UI,
+    // guarantees well-formed guesses.
+    component guessGeq1 = GreaterEqThan(16);
+    guessGeq1.in[0] <== guess;
+    guessGeq1.in[1] <== 1;
+    guessGeq1.out === 1;
+
+    component guessLeqMax = LessEqThan(16);
+    guessLeqMax.in[0] <== guess;
+    guessLeqMax.in[1] <== maxNumber;
+    guessLeqMax.out === 1;
+
     // Generate commitment using Poseidon hash
     component hasher = Poseidon(2);
     hasher.inputs[0] <== number;

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "compile": "tsx scripts/compile.ts",
-    "setup": "tsx scripts/setup.ts",
-    "build": "bun run compile && bun run setup",
+    "setup:dev": "tsx scripts/setup-dev.ts",
+    "build": "bun run compile && bun run setup:dev",
     "export-verifier": "tsx scripts/export-verifier.ts",
     "copy-to-contracts": "./scripts/copy-artifacts.sh"
   },

--- a/scripts/copy-artifacts.sh
+++ b/scripts/copy-artifacts.sh
@@ -18,6 +18,10 @@ CONTRACTS_DIR="$CIRCUITS_DIR/../zk-guess-contracts"
 mkdir -p "$CONTRACTS_DIR/circuits"
 mkdir -p "$CONTRACTS_DIR/src/generated"
 
+# Regenerate the Solidity verifier from the current dev zkey so we never ship
+# a GuessVerifier.sol that drifted from the zkey sitting next to it.
+(cd "$CIRCUITS_DIR" && bun run export-verifier)
+
 cp "$CIRCUITS_DIR/circuits/guess.circom" "$CONTRACTS_DIR/circuits/guess.circom"
 cp "$CIRCUITS_DIR/generated/GuessVerifier.sol" "$CONTRACTS_DIR/src/generated/GuessVerifier.sol"
 cp "$CIRCUITS_DIR/generated/guess_js/guess.wasm" "$CONTRACTS_DIR/circuits/guess.wasm"

--- a/scripts/copy-artifacts.sh
+++ b/scripts/copy-artifacts.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
+set -euo pipefail
 
-# Script to copy circuit artifacts to contracts repository
-# NOTE: This script assumes the contracts repo is in a sibling directory
-# Directory structure should be:
+# Copy dev circuit artifacts to contracts repo (sibling directory).
+# These are DEV artifacts from scripts/setup-dev.ts — not ceremony output.
+# Shipping artifacts (guess_final.zkey from the phase-2 ceremony) are copied
+# separately once the ceremony lands.
+#
+# Directory layout:
 #   parent/
 #     zk-guess-circuits/  (this repo)
 #     zk-guess-contracts/ (contracts repo)
@@ -11,18 +15,27 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CIRCUITS_DIR="$(dirname "$SCRIPT_DIR")"
 CONTRACTS_DIR="$CIRCUITS_DIR/../zk-guess-contracts"
 
-# Ensure directories exist
 mkdir -p "$CONTRACTS_DIR/circuits"
 mkdir -p "$CONTRACTS_DIR/src/generated"
 
-# Copy circuit file
 cp "$CIRCUITS_DIR/circuits/guess.circom" "$CONTRACTS_DIR/circuits/guess.circom"
-
-# Copy verifier contract
 cp "$CIRCUITS_DIR/generated/GuessVerifier.sol" "$CONTRACTS_DIR/src/generated/GuessVerifier.sol"
-
-# Copy wasm and zkey for FFI proof generation in tests
 cp "$CIRCUITS_DIR/generated/guess_js/guess.wasm" "$CONTRACTS_DIR/circuits/guess.wasm"
-cp "$CIRCUITS_DIR/generated/guess_final.zkey" "$CONTRACTS_DIR/circuits/guess_final.zkey"
+cp "$CIRCUITS_DIR/generated/guess_dev.zkey" "$CONTRACTS_DIR/circuits/guess_dev.zkey"
 
-echo "✓ Copied artifacts to contracts repo"
+SRC_SHA="$(git -C "$CIRCUITS_DIR" rev-parse HEAD)"
+SRC_DESCRIBE="$(git -C "$CIRCUITS_DIR" describe --always --dirty)"
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+cat > "$CONTRACTS_DIR/circuits/BUILD_INFO.txt" <<EOF
+BUILD=dev
+WARNING: These artifacts are from a single-contributor dev setup, NOT a trusted-setup ceremony.
+Do not deploy the derived GuessVerifier.sol to mainnet. Shipping artifacts will be copied
+separately after the phase-2 ceremony produces guess_final.zkey.
+SOURCE_REPO=chainhackers/zk-guess-circuits
+SOURCE_SHA=$SRC_SHA
+SOURCE_DESCRIBE=$SRC_DESCRIBE
+COPIED_AT=$TIMESTAMP
+EOF
+
+echo "✓ Copied dev artifacts to contracts repo (BUILD=dev, $SRC_DESCRIBE)"

--- a/scripts/copy-artifacts.sh
+++ b/scripts/copy-artifacts.sh
@@ -15,6 +15,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CIRCUITS_DIR="$(dirname "$SCRIPT_DIR")"
 CONTRACTS_DIR="$CIRCUITS_DIR/../zk-guess-contracts"
 
+# shellcheck source=lib/build-info.sh
+source "$SCRIPT_DIR/lib/build-info.sh"
+
 mkdir -p "$CONTRACTS_DIR/circuits"
 mkdir -p "$CONTRACTS_DIR/src/generated"
 
@@ -27,19 +30,7 @@ cp "$CIRCUITS_DIR/generated/GuessVerifier.sol" "$CONTRACTS_DIR/src/generated/Gue
 cp "$CIRCUITS_DIR/generated/guess_js/guess.wasm" "$CONTRACTS_DIR/circuits/guess.wasm"
 cp "$CIRCUITS_DIR/generated/guess_dev.zkey" "$CONTRACTS_DIR/circuits/guess_dev.zkey"
 
-SRC_SHA="$(git -C "$CIRCUITS_DIR" rev-parse HEAD)"
-SRC_DESCRIBE="$(git -C "$CIRCUITS_DIR" describe --always --dirty)"
-TIMESTAMP="$(LC_ALL=C date -u +%Y-%m-%dT%H:%M:%SZ)"
+describe=$(write_build_info "$CIRCUITS_DIR" "$CONTRACTS_DIR/circuits" \
+    "Single-contributor dev setup, NOT a trusted-setup ceremony. Do not deploy the derived GuessVerifier.sol to mainnet. Shipping artifacts will be copied separately after the phase-2 ceremony produces guess_final.zkey.")
 
-cat > "$CONTRACTS_DIR/circuits/BUILD_INFO.txt" <<EOF
-BUILD=dev
-WARNING: These artifacts are from a single-contributor dev setup, NOT a trusted-setup ceremony.
-Do not deploy the derived GuessVerifier.sol to mainnet. Shipping artifacts will be copied
-separately after the phase-2 ceremony produces guess_final.zkey.
-SOURCE_REPO=chainhackers/zk-guess-circuits
-SOURCE_SHA=$SRC_SHA
-SOURCE_DESCRIBE=$SRC_DESCRIBE
-COPIED_AT=$TIMESTAMP
-EOF
-
-echo "✓ Copied dev artifacts to contracts repo (BUILD=dev, $SRC_DESCRIBE)"
+echo "✓ Copied dev artifacts to contracts repo (BUILD=dev, $describe)"

--- a/scripts/copy-artifacts.sh
+++ b/scripts/copy-artifacts.sh
@@ -25,7 +25,7 @@ cp "$CIRCUITS_DIR/generated/guess_dev.zkey" "$CONTRACTS_DIR/circuits/guess_dev.z
 
 SRC_SHA="$(git -C "$CIRCUITS_DIR" rev-parse HEAD)"
 SRC_DESCRIBE="$(git -C "$CIRCUITS_DIR" describe --always --dirty)"
-TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+TIMESTAMP="$(LC_ALL=C date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 cat > "$CONTRACTS_DIR/circuits/BUILD_INFO.txt" <<EOF
 BUILD=dev

--- a/scripts/copy-to-frontend.sh
+++ b/scripts/copy-to-frontend.sh
@@ -16,7 +16,7 @@ cp "$CIRCUITS_DIR/generated/guess_dev_verification_key.json" "$FRONTEND_DIR/publ
 
 SRC_SHA="$(git -C "$CIRCUITS_DIR" rev-parse HEAD)"
 SRC_DESCRIBE="$(git -C "$CIRCUITS_DIR" describe --always --dirty)"
-TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+TIMESTAMP="$(LC_ALL=C date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 cat > "$FRONTEND_DIR/public/circuits/BUILD_INFO.txt" <<EOF
 BUILD=dev

--- a/scripts/copy-to-frontend.sh
+++ b/scripts/copy-to-frontend.sh
@@ -8,23 +8,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CIRCUITS_DIR="$(dirname "$SCRIPT_DIR")"
 FRONTEND_DIR="$CIRCUITS_DIR/../zk-guess/frontend"
 
+# shellcheck source=lib/build-info.sh
+source "$SCRIPT_DIR/lib/build-info.sh"
+
 mkdir -p "$FRONTEND_DIR/public/circuits"
 
 cp "$CIRCUITS_DIR/generated/guess_js/guess.wasm" "$FRONTEND_DIR/public/circuits/"
 cp "$CIRCUITS_DIR/generated/guess_dev.zkey" "$FRONTEND_DIR/public/circuits/"
 cp "$CIRCUITS_DIR/generated/guess_dev_verification_key.json" "$FRONTEND_DIR/public/circuits/"
 
-SRC_SHA="$(git -C "$CIRCUITS_DIR" rev-parse HEAD)"
-SRC_DESCRIBE="$(git -C "$CIRCUITS_DIR" describe --always --dirty)"
-TIMESTAMP="$(LC_ALL=C date -u +%Y-%m-%dT%H:%M:%SZ)"
+describe=$(write_build_info "$CIRCUITS_DIR" "$FRONTEND_DIR/public/circuits" \
+    "Dev-setup artifacts, not ceremony output. Safe for local testing only.")
 
-cat > "$FRONTEND_DIR/public/circuits/BUILD_INFO.txt" <<EOF
-BUILD=dev
-WARNING: Dev-setup artifacts, not ceremony output. Safe for local testing only.
-SOURCE_REPO=chainhackers/zk-guess-circuits
-SOURCE_SHA=$SRC_SHA
-SOURCE_DESCRIBE=$SRC_DESCRIBE
-COPIED_AT=$TIMESTAMP
-EOF
-
-echo "✓ Copied dev circuit artifacts to frontend (BUILD=dev, $SRC_DESCRIBE)"
+echo "✓ Copied dev circuit artifacts to frontend (BUILD=dev, $describe)"

--- a/scripts/copy-to-frontend.sh
+++ b/scripts/copy-to-frontend.sh
@@ -1,16 +1,30 @@
 #!/bin/bash
+set -euo pipefail
 
-# Copy circuit artifacts to frontend
+# Copy DEV circuit artifacts to the frontend (sibling zk-guess/frontend).
+# These are dev-setup artifacts, not ceremony output — BUILD_INFO.txt marks them so.
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CIRCUITS_DIR="$(dirname "$SCRIPT_DIR")"
 FRONTEND_DIR="$CIRCUITS_DIR/../zk-guess/frontend"
 
-# Create directories
 mkdir -p "$FRONTEND_DIR/public/circuits"
 
-# Copy files
 cp "$CIRCUITS_DIR/generated/guess_js/guess.wasm" "$FRONTEND_DIR/public/circuits/"
-cp "$CIRCUITS_DIR/generated/guess_final.zkey" "$FRONTEND_DIR/public/circuits/"
-cp "$CIRCUITS_DIR/generated/guess_verification_key.json" "$FRONTEND_DIR/public/circuits/"
+cp "$CIRCUITS_DIR/generated/guess_dev.zkey" "$FRONTEND_DIR/public/circuits/"
+cp "$CIRCUITS_DIR/generated/guess_dev_verification_key.json" "$FRONTEND_DIR/public/circuits/"
 
-echo "✓ Copied circuit artifacts to frontend"
+SRC_SHA="$(git -C "$CIRCUITS_DIR" rev-parse HEAD)"
+SRC_DESCRIBE="$(git -C "$CIRCUITS_DIR" describe --always --dirty)"
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+cat > "$FRONTEND_DIR/public/circuits/BUILD_INFO.txt" <<EOF
+BUILD=dev
+WARNING: Dev-setup artifacts, not ceremony output. Safe for local testing only.
+SOURCE_REPO=chainhackers/zk-guess-circuits
+SOURCE_SHA=$SRC_SHA
+SOURCE_DESCRIBE=$SRC_DESCRIBE
+COPIED_AT=$TIMESTAMP
+EOF
+
+echo "✓ Copied dev circuit artifacts to frontend (BUILD=dev, $SRC_DESCRIBE)"

--- a/scripts/export-verifier.ts
+++ b/scripts/export-verifier.ts
@@ -8,7 +8,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 async function exportVerifier() {
   console.log("Exporting Solidity verifier...");
   
-  const zkeyPath = path.join(__dirname, "..", "generated", "guess_final.zkey");
+  const zkeyPath = path.join(__dirname, "..", "generated", "guess_dev.zkey");
   const verifierPath = path.join(__dirname, "..", "generated", "GuessVerifier.sol");
   
   try {

--- a/scripts/generate-test-proofs.ts
+++ b/scripts/generate-test-proofs.ts
@@ -4,8 +4,8 @@
 import { generateProof, calculateCommitment, getCircuitPaths } from "../test/utils";
 import type { CircuitInputs } from "../test/utils";
 
-// Test address (0x1234567890123456789012345678901234567890)
-const ALICE = "104134845626036279338909600961366137424362805893520";
+// Test address 0x1234567890123456789012345678901234567890 as a decimal uint160.
+const ALICE = BigInt("0x1234567890123456789012345678901234567890").toString();
 
 interface Scenario {
   label: string;

--- a/scripts/generate-test-proofs.ts
+++ b/scripts/generate-test-proofs.ts
@@ -1,139 +1,90 @@
+// Print Solidity-formatted proof fixtures for the contracts repo (Foundry FFI).
+// Emits one block per scenario with pA, pB, pC, and the v2 public signals:
+//   [commitment, isCorrect, guess, maxNumber, puzzleId, guesser]
 import { generateProof, calculateCommitment, getCircuitPaths } from "../test/utils";
 import type { CircuitInputs } from "../test/utils";
 
+// Test address (0x1234567890123456789012345678901234567890)
+const ALICE = "104134845626036279338909600961366137424362805893520";
+
+interface Scenario {
+  label: string;
+  suffix: string;
+  inputs: CircuitInputs;
+}
+
+const SCENARIOS: Scenario[] = [
+  {
+    label: "CORRECT GUESS (42)",
+    suffix: "correct",
+    inputs: { number: "42", salt: "123", guess: "42", maxNumber: "100", puzzleId: "7", guesser: ALICE },
+  },
+  {
+    label: "INCORRECT GUESS (50)",
+    suffix: "incorrect",
+    inputs: { number: "42", salt: "123", guess: "50", maxNumber: "100", puzzleId: "7", guesser: ALICE },
+  },
+  {
+    label: "INCORRECT GUESS (99)",
+    suffix: "incorrect_99",
+    inputs: { number: "42", salt: "123", guess: "99", maxNumber: "100", puzzleId: "7", guesser: ALICE },
+  },
+];
+
+function formatProofForSolidity(proof: any, publicSignals: string[]) {
+  return {
+    pA: [proof.pi_a[0], proof.pi_a[1]],
+    pB: [[proof.pi_b[0][1], proof.pi_b[0][0]], [proof.pi_b[1][1], proof.pi_b[1][0]]],
+    pC: [proof.pi_c[0], proof.pi_c[1]],
+    pubSignals: publicSignals,
+  };
+}
+
+function printSolidityBlock(label: string, suffix: string, p: ReturnType<typeof formatProofForSolidity>) {
+  console.log(`\n=== PROOF FOR ${label} ===`);
+  console.log(`uint[2] validProofA_${suffix} = [`);
+  console.log(`    ${p.pA[0]},`);
+  console.log(`    ${p.pA[1]}`);
+  console.log(`];`);
+
+  console.log(`uint[2][2] validProofB_${suffix} = [`);
+  console.log(`    [${p.pB[0][0]},`);
+  console.log(`     ${p.pB[0][1]}],`);
+  console.log(`    [${p.pB[1][0]},`);
+  console.log(`     ${p.pB[1][1]}]`);
+  console.log(`];`);
+
+  console.log(`uint[2] validProofC_${suffix} = [`);
+  console.log(`    ${p.pC[0]},`);
+  console.log(`    ${p.pC[1]}`);
+  console.log(`];`);
+
+  console.log(`uint[6] validPubSignals_${suffix} = [`);
+  console.log(`    uint256(${p.pubSignals[0]}), // commitment`);
+  console.log(`    ${p.pubSignals[1]}, // isCorrect`);
+  console.log(`    ${p.pubSignals[2]}, // guess`);
+  console.log(`    ${p.pubSignals[3]}, // maxNumber`);
+  console.log(`    ${p.pubSignals[4]}, // puzzleId`);
+  console.log(`    ${p.pubSignals[5]}  // guesser`);
+  console.log(`];`);
+}
+
 async function generateTestProofs() {
   const circuitPaths = getCircuitPaths("guess");
-  
-  // Test case 1: number=42, salt=123, correct guess
-  const inputs1: CircuitInputs = {
-    number: "42",
-    salt: "123",
-    guess: "42"
-  };
-  
-  console.log("Generating proof for correct guess (42)...");
-  const { proof: proof1, publicSignals: signals1 } = await generateProof(
-    inputs1,
-    circuitPaths.wasmPath,
-    circuitPaths.zkeyPath
-  );
-  
+
   const commitment = await calculateCommitment(42, 123);
-  console.log("Commitment for (42, 123):", commitment);
-  console.log("Expected commitment hex:", "0x" + BigInt(commitment).toString(16));
-  
-  // Test case 2: number=42, salt=123, incorrect guess (50)
-  const inputs2: CircuitInputs = {
-    number: "42",
-    salt: "123",
-    guess: "50"
-  };
-  
-  console.log("\nGenerating proof for incorrect guess (50)...");
-  const { proof: proof2, publicSignals: signals2 } = await generateProof(
-    inputs2,
-    circuitPaths.wasmPath,
-    circuitPaths.zkeyPath
-  );
+  console.log(`Commitment for (42, 123) under DOMAIN_TAG: ${commitment}`);
+  console.log(`Expected commitment hex: 0x${BigInt(commitment).toString(16)}`);
 
-  const inputs3: CircuitInputs = {
-    number: "42",
-    salt: "123",
-    guess: "99"
-  };
-
-  console.log("\nGenerating proof for incorrect guess (99)...");
-  const { proof: proof3, publicSignals: signals3 } = await generateProof(
-    inputs3,
-    circuitPaths.wasmPath,
-    circuitPaths.zkeyPath
-  );
-
-  // Format proofs for Solidity
-  const formatProofForSolidity = (proof: any, publicSignals: string[]) => {
-    return {
-      pA: [proof.pi_a[0], proof.pi_a[1]],
-      pB: [[proof.pi_b[0][1], proof.pi_b[0][0]], [proof.pi_b[1][1], proof.pi_b[1][0]]],
-      pC: [proof.pi_c[0], proof.pi_c[1]],
-      pubSignals: publicSignals
-    };
-  };
-  
-  const solidityProof1 = formatProofForSolidity(proof1, signals1);
-  const solidityProof2 = formatProofForSolidity(proof2, signals2);
-  const solidityProof3 = formatProofForSolidity(proof3, signals3);
-  
-  console.log("\n=== PROOF FOR CORRECT GUESS (42) ===");
-  console.log("uint[2] validProofA_correct = [");
-  console.log(`    ${solidityProof1.pA[0]},`);
-  console.log(`    ${solidityProof1.pA[1]}`);
-  console.log("];");
-  
-  console.log("uint[2][2] validProofB_correct = [");
-  console.log(`    [${solidityProof1.pB[0][0]},`);
-  console.log(`     ${solidityProof1.pB[0][1]}],`);
-  console.log(`    [${solidityProof1.pB[1][0]},`);
-  console.log(`     ${solidityProof1.pB[1][1]}]`);
-  console.log("];");
-  
-  console.log("uint[2] validProofC_correct = [");
-  console.log(`    ${solidityProof1.pC[0]},`);
-  console.log(`    ${solidityProof1.pC[1]}`);
-  console.log("];");
-  
-  console.log("uint[3] validPubSignals_correct = [");
-  console.log(`    uint256(${solidityProof1.pubSignals[0]}),`);
-  console.log(`    ${solidityProof1.pubSignals[1]}, // isCorrect`);
-  console.log(`    ${solidityProof1.pubSignals[2]} //guess`);
-  console.log("];");
-  
-  console.log("\n=== PROOF FOR INCORRECT GUESS (50) ===");
-  console.log("uint[2] validProofA_incorrect = [");
-  console.log(`    ${solidityProof2.pA[0]},`);
-  console.log(`    ${solidityProof2.pA[1]}`);
-  console.log("];");
-  
-  console.log("uint[2][2] validProofB_incorrect = [");
-  console.log(`    [${solidityProof2.pB[0][0]},`);
-  console.log(`     ${solidityProof2.pB[0][1]}],`);
-  console.log(`    [${solidityProof2.pB[1][0]},`);
-  console.log(`     ${solidityProof2.pB[1][1]}]`);
-  console.log("];");
-  
-  console.log("uint[2] validProofC_incorrect = [");
-  console.log(`    ${solidityProof2.pC[0]},`);
-  console.log(`    ${solidityProof2.pC[1]}`);
-  console.log("];");
-  
-  console.log("uint[3] validPubSignals_incorrect = [");
-  console.log(`    uint256(${solidityProof2.pubSignals[0]}),`);
-  console.log(`    ${solidityProof2.pubSignals[1]}, // isCorrect`);
-  console.log(`    ${solidityProof2.pubSignals[2]} //guess`);
-  console.log("];");
-
-  console.log("\n=== PROOF FOR INCORRECT GUESS (99) ===");
-  console.log("uint[2] validProofA_incorrect_99 = [");
-  console.log(`    ${solidityProof3.pA[0]},`);
-  console.log(`    ${solidityProof3.pA[1]}`);
-  console.log("];");
-
-  console.log("uint[2][2] validProofB_incorrect_99 = [");
-  console.log(`    [${solidityProof3.pB[0][0]},`);
-  console.log(`     ${solidityProof3.pB[0][1]}],`);
-  console.log(`    [${solidityProof3.pB[1][0]},`);
-  console.log(`     ${solidityProof3.pB[1][1]}]`);
-  console.log("];");
-
-  console.log("uint[2] validProofC_incorrect_99 = [");
-  console.log(`    ${solidityProof3.pC[0]},`);
-  console.log(`    ${solidityProof3.pC[1]}`);
-  console.log("];");
-
-  console.log("uint[3] validPubSignals_incorrect_99 = [");
-  console.log(`    uint256(${solidityProof3.pubSignals[0]}),`);
-  console.log(`    ${solidityProof3.pubSignals[1]}, // isCorrect`);
-  console.log(`    ${solidityProof3.pubSignals[2]} //guess`);
-  console.log("];");
+  for (const scenario of SCENARIOS) {
+    console.log(`\nGenerating proof: ${scenario.label}...`);
+    const { proof, publicSignals } = await generateProof(
+      scenario.inputs,
+      circuitPaths.wasmPath,
+      circuitPaths.zkeyPath
+    );
+    printSolidityBlock(scenario.label, scenario.suffix, formatProofForSolidity(proof, publicSignals));
+  }
 }
 
 generateTestProofs().catch(console.error);

--- a/scripts/generate-test-proofs.ts
+++ b/scripts/generate-test-proofs.ts
@@ -3,9 +3,7 @@
 //   [commitment, isCorrect, guess, maxNumber, puzzleId, guesser]
 import { generateProof, calculateCommitment, getCircuitPaths } from "../test/utils";
 import type { CircuitInputs } from "../test/utils";
-
-// Test address 0x1234567890123456789012345678901234567890 as a decimal uint160.
-const ALICE = BigInt("0x1234567890123456789012345678901234567890").toString();
+import { ALICE } from "../src/constants";
 
 interface Scenario {
   label: string;

--- a/scripts/lib/build-info.sh
+++ b/scripts/lib/build-info.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# write_build_info <circuits_repo_dir> <dest_dir> <warning>
+# Emits a BUILD_INFO.txt in <dest_dir> stamping the source commit, describe,
+# timestamp, and a caller-supplied warning line. Sourced by copy scripts.
+write_build_info() {
+    local circuits_dir="$1"
+    local dest_dir="$2"
+    local warning="$3"
+
+    local src_sha src_describe timestamp
+    src_sha="$(git -C "$circuits_dir" rev-parse HEAD)"
+    src_describe="$(git -C "$circuits_dir" describe --always --dirty)"
+    timestamp="$(LC_ALL=C date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    cat > "$dest_dir/BUILD_INFO.txt" <<EOF
+BUILD=dev
+WARNING: $warning
+SOURCE_REPO=chainhackers/zk-guess-circuits
+SOURCE_SHA=$src_sha
+SOURCE_DESCRIBE=$src_describe
+COPIED_AT=$timestamp
+EOF
+
+    echo "$src_describe"
+}

--- a/scripts/setup-dev.ts
+++ b/scripts/setup-dev.ts
@@ -49,57 +49,56 @@ async function downloadPtau() {
   }
 }
 
-async function setup() {
-  console.log("Running trusted setup...");
-  
+// Dev-only Groth16 setup: single local contribution with random entropy.
+// NOT a real ceremony. Produces guess_dev.zkey + guess_dev_verification_key.json.
+// The shipping guess_final.zkey comes from the phase-2 multi-party ceremony,
+// which runs out-of-band and is not wired into this script.
+async function setupDev() {
+  console.log("Running dev trusted setup (single contributor, NOT a ceremony)...");
+
   const generatedDir = path.join(__dirname, "..", "generated");
   const r1csPath = path.join(generatedDir, "guess.r1cs");
   const ptauPath = await downloadPtau();
-  
-  // Check if r1cs exists
+
   try {
     await fs.access(r1csPath);
   } catch {
-    console.error("Error: R1CS file not found. Run 'npm run compile' first.");
+    console.error("Error: R1CS file not found. Run 'bun run compile' first.");
     process.exit(1);
   }
-  
+
   try {
-    // Generate initial zkey
     const zkey0Path = path.join(generatedDir, "guess_0000.zkey");
     console.log("Generating initial zkey...");
-    
+
     await zKey.newZKey(r1csPath, ptauPath, zkey0Path);
     console.log("✓ Initial zkey generated");
-    
-    // Add contribution (for dev)
-    const zkeyFinalPath = path.join(generatedDir, "guess_final.zkey");
-    console.log("Adding contribution...");
+
+    const zkeyDevPath = path.join(generatedDir, "guess_dev.zkey");
+    console.log("Adding dev contribution...");
 
     const entropy = crypto.randomBytes(32).toString("hex");
     await zKey.contribute(
       zkey0Path,
-      zkeyFinalPath,
+      zkeyDevPath,
       "Dev contribution",
       entropy
     );
     console.log("✓ Contribution added");
-    
-    // Export verification key
+
     console.log("Exporting verification key...");
-    const vKey = await zKey.exportVerificationKey(zkeyFinalPath);
-    
-    const vKeyPath = path.join(generatedDir, "guess_verification_key.json");
+    const vKey = await zKey.exportVerificationKey(zkeyDevPath);
+
+    const vKeyPath = path.join(generatedDir, "guess_dev_verification_key.json");
     await fs.writeFile(vKeyPath, JSON.stringify(vKey, null, 2));
     console.log("✓ Verification key exported");
-    
-    // Clean up intermediate files
+
     await fs.unlink(zkey0Path);
     console.log("✓ Cleaned up intermediate files");
-    
-    console.log("\n✅ Setup complete!");
-    console.log(`  - Final zkey: ${zkeyFinalPath}`);
-    console.log(`  - Verification key: ${vKeyPath}`);
+
+    console.log("\n✅ Dev setup complete!");
+    console.log(`  - Dev zkey: ${zkeyDevPath}`);
+    console.log(`  - Dev verification key: ${vKeyPath}`);
 
     process.exit(0);
   } catch (error) {
@@ -108,4 +107,4 @@ async function setup() {
   }
 }
 
-setup();
+setupDev();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,12 @@
+// Shared v2 circuit constants. The circuit (circuits/guess.circom) hard-codes
+// the same DOMAIN_TAG literal. Downstream consumers (zk-guess frontend) should
+// import from this file so the circuit and client never drift.
+
+// keccak256("zkguess.v2") mod p(BN254). Hashes the 10 ASCII bytes of the string
+// "zkguess.v2" (no trailing newline), reduced modulo the BN254 scalar field.
+// Reproduce with:
+//   node -e 'const {keccak256}=require("js-sha3");
+//     const P=21888242871839275222246405745257275088548364400416034343698204186575808495617n;
+//     console.log((BigInt("0x"+keccak256("zkguess.v2")) % P).toString());'
+export const DOMAIN_TAG_PREIMAGE = "zkguess.v2";
+export const DOMAIN_TAG = 6000605569458108169701754207643449997818461959397281845176039583157698733685n;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,3 +10,8 @@
 //     console.log((BigInt("0x"+keccak256("zkguess.v2")) % P).toString());'
 export const DOMAIN_TAG_PREIMAGE = "zkguess.v2";
 export const DOMAIN_TAG = 6000605569458108169701754207643449997818461959397281845176039583157698733685n;
+
+// Test uint160s used as fixture `guesser` values in tests and proof generators.
+// Derived from hex literals so the decimal form cannot drift from the address.
+export const ALICE = BigInt("0x1234567890123456789012345678901234567890").toString();
+export const BOB = BigInt("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").toString();

--- a/tasks/bind-guesser.md
+++ b/tasks/bind-guesser.md
@@ -1,0 +1,50 @@
+# Bind proof to guesser address (optional)
+
+Part of the `v2` circuit redesign. Sibling plan: `zk-guess-contracts/docs/superpowers/specs/2026-04-23-clean-redeploy-antimixer-design.md`.
+
+**Status: optional.** Ship if it doesn't push the trusted-setup ceremony timeline; skip otherwise. Marginal value for the target threat model.
+
+## Goal
+
+Add `guesser` (an Ethereum address, fits in a single 160-bit field element) as a public input to the circuit, bound into the proof. Prevents a third party from front-running someone else's proof submission by replaying it with the same witness but under their own `msg.sender`. Not a fund-at-risk scenario (prize goes to `challenge.guesser` regardless), but cleaner proof hygiene and another semantic differentiator from mixers (which carefully *avoid* binding proofs to specific addresses — the whole point of a mixer is unlinkability).
+
+## Changes
+
+In `circuits/guess.circom`:
+
+```circom
+signal input guesser;  // uint160 as a field element
+
+// force into constraint system, same technique as puzzleId binding
+signal guesserSquared;
+guesserSquared <== guesser * guesser;
+```
+
+Add `guesser` to the public input list: `public [guess, maxNumber, puzzleId, guesser]`. Final public signals: `[commitment, isCorrect, guess, maxNumber, puzzleId, guesser]` (6 total).
+
+Contract side (`zk-guess-contracts`):
+- `respondToChallenge` reads `_pubSignals[5]` and reverts with `InvalidGuesserBinding()` if it doesn't match the stored `challenges[challengeId].guesser`.
+
+Frontend side (`zk-guess`):
+- `generate-proof.js` passes `guesser: <msg.sender address as uint>` as an additional input.
+
+## Decision gate
+
+Only ship if:
+1. The trusted-setup ceremony can accommodate an extra public input without re-scheduling contributors.
+2. `snarkjs` bn254 tooling handles 160-bit inputs cleanly (should be trivial — addresses fit easily in BN254's 254-bit field).
+3. Frontend client has `msg.sender` available at proof-gen time (it does — wallet connection provides it).
+
+If any of these is borderline, skip this task and ship the other three circuit changes. Can be added in v3.
+
+## Tests
+
+- **Positive**: proof generated with `guesser = Alice` verifies with `_pubSignals[5] == uint256(Alice)`.
+- **Negative (front-run attempt)**: take Alice's valid proof, try to call `respondToChallenge` as Bob — contract reverts.
+- **Witness soundness**: witness with mismatched `guesser` vs public input fails constraint check.
+
+## Acceptance
+
+- Constraint count grows by ≤ 5 (the `guesserSquared` multiplication).
+- Test suite covers front-run attempt via contract-side fixture.
+- If not shipped, document why in the `v2` spec's "Decisions (locked)" section.

--- a/tasks/bind-puzzle-id.md
+++ b/tasks/bind-puzzle-id.md
@@ -1,0 +1,43 @@
+# Bind proof to puzzleId
+
+Track: part of the `v2` circuit redesign for zk-guess. Sibling plan lives at `zk-guess-contracts/docs/superpowers/specs/2026-04-23-clean-redeploy-antimixer-design.md`.
+
+## Goal
+
+Make each Groth16 proof **intrinsically scoped to a specific puzzle** by adding `puzzleId` as a public input. A valid proof for puzzle A cannot be replayed on puzzle B even if A and B share the same commitment (which is rare but possible if two creators pick the same secret + salt). Closes a silent replay surface and — equally important for the anti-mixer narrative — makes it visually obvious at the circuit level that every proof is deposit-scoped. Mixers go to great lengths to *not* bind proofs to specific deposits.
+
+## Changes
+
+In `circuits/guess.circom`:
+
+- Add `signal input puzzleId;` at the top of `GuessNumber()`.
+- Add `puzzleId` to the `component main { public [...] }` list at the bottom: `public [guess, maxNumber, puzzleId]`.
+- Multiply-and-discard the signal to force it into the constraint system so that the prover cannot change `puzzleId` without invalidating the proof. Idiomatic Circom pattern:
+  ```circom
+  signal puzzleIdSquared;
+  puzzleIdSquared <== puzzleId * puzzleId;
+  ```
+  The `puzzleIdSquared` value is unused; the constraint is what matters.
+
+Public signals, post-change: `[commitment, isCorrect, guess, maxNumber, puzzleId]` (5 total).
+
+Contract-side consumer change (tracked separately in `zk-guess-contracts`):
+- `GuessGame.respondToChallenge` reads `_pubSignals[4]` and reverts with `InvalidPuzzleIdBinding()` if it doesn't match the stored `challengeToPuzzle[challengeId]`.
+
+Frontend-side consumer change (tracked in `zk-guess` frontend):
+- `generate-proof.js` / client-side proof gen passes `puzzleId: <uint256>` as an additional input.
+
+## Tests
+
+In `test/guess.test.ts`:
+
+- **Positive**: proof generated with `puzzleId = 7` verifies successfully; the verifier output includes `puzzleId = 7` as public signal 4.
+- **Negative (rebind attempt)**: take a valid proof for `puzzleId = 7`, try to submit it claiming `puzzleId = 8` — verification fails.
+- **Constraint soundness**: attempt to generate a proof with a witness where `puzzleId` in the witness differs from `puzzleId` in the public inputs. Circom's witness calculator should either refuse or the proof should not verify.
+
+## Acceptance
+
+- `circom guess.circom --r1cs --wasm --sym` produces R1CS with one extra public input and one extra constraint (the `puzzleIdSquared` multiplication).
+- `snarkjs groth16 verify` returns `true` for a proof where `puzzleId` matches witness, `false` where it differs.
+- Test suite green.
+- Number of constraints grows by ≤ 5 (dominated by the range-check task, not this one).

--- a/tasks/domain-separate-commitment.md
+++ b/tasks/domain-separate-commitment.md
@@ -1,0 +1,55 @@
+# Domain-separate the commitment hash
+
+Part of the `v2` circuit redesign. Sibling plan: `zk-guess-contracts/docs/superpowers/specs/2026-04-23-clean-redeploy-antimixer-design.md`.
+
+## Goal
+
+Replace `Poseidon([number, salt])` with `Poseidon([DOMAIN_TAG, number, salt])` where `DOMAIN_TAG` is a hard-coded circuit constant derived from `keccak256("zkguess.v2") mod p` (BN254 scalar field).
+
+Domain separation guarantees v1 commitments can never be confused with v2 commitments under any future composition (for example, if both systems ever co-exist in a shared rollup or registry, or if a cross-protocol proof aggregation ever emerges). Standard practice on protocol upgrades; contributes to the "this is clearly a different system from v1" narrative for scanners and auditors.
+
+## Changes
+
+In `circuits/guess.circom`:
+
+- Replace `component hasher = Poseidon(2);` with `Poseidon(3)`.
+- Hard-code the domain tag as a field-element constant at the top of the template:
+  ```circom
+  // keccak256("zkguess.v2") mod p(BN254)
+  // pre-computed offline and committed here verbatim
+  var DOMAIN_TAG = <field element hex or decimal literal>;
+  ```
+  The exact value must be computed by the ceremony operator and committed as part of this task.
+- Pass it as the first input: `hasher.inputs[0] <== DOMAIN_TAG;`, then `hasher.inputs[1] <== number;`, `hasher.inputs[2] <== salt;`.
+
+Frontend consumer change (tracked in `zk-guess` frontend):
+- `computeCommitment(number, salt)` must be updated to also include the same `DOMAIN_TAG`. The tag value should be exported from a shared module (e.g., `constants/v2.ts`) so circuit + client use the same literal.
+
+Indexer consumer change (`zk-guess-indexer`):
+- None required — indexer doesn't reconstruct commitments.
+
+Contract consumer change:
+- None required — contract treats commitment as opaque `bytes32`.
+
+## DOMAIN_TAG computation (done once, committed to the circuit)
+
+```bash
+# pseudocode
+K=$(echo -n "zkguess.v2" | xxd -p | xxd -r -p | keccak256sum)
+P=21888242871839275222246405745257275088548364400416034343698204186575808495617  # BN254 scalar field modulus
+python -c "print(int('${K}', 16) % ${P})"
+```
+
+Commit this constant in the circuit AND in a shared config module consumed by the frontend.
+
+## Tests
+
+- **Positive**: commitment produced by the new circuit for `(number=42, salt=X)` matches the client-side `Poseidon3([DOMAIN_TAG, 42, X])`.
+- **Negative: v1 regression**: a commitment produced with the old `Poseidon2([number, salt])` no longer verifies under the new circuit.
+- **Cross-domain safety**: two commitments with identical `(number, salt)` but different DOMAIN_TAG (e.g., `"zkguess.v2"` vs `"zkguess.v3"`) are distinct.
+
+## Acceptance
+
+- Circuit compiles; one extra Poseidon input increases the constraint count by a small amount.
+- Shared constant exported and linked from NatSpec of `GuessGame` via `@custom:commitment-domain`.
+- Frontend commitment-gen updated and unit-tested against the circuit output.

--- a/tasks/publish-artifacts-release.md
+++ b/tasks/publish-artifacts-release.md
@@ -1,0 +1,67 @@
+# Publish circuit artifacts as a GitHub Release
+
+Part of the `v2` circuit redesign. Sibling plan: `zk-guess-contracts/docs/superpowers/specs/2026-04-23-clean-redeploy-antimixer-design.md`.
+
+## Goal
+
+Host the final v2 circuit artifacts as a pinned, checksummed GitHub Release at `chainhackers/zk-guess-circuits/releases/tag/v2.0.0`. A scanner or auditor who reads the `@custom:circuit-repo` tag on the contract should be one click away from reproducible proof that the on-chain verifier matches the claimed circuit.
+
+This is the single strongest legitimacy marker we can ship without engaging a paid audit: *"Here is the circuit source, here is the R1CS, here is the trusted-setup transcript, here is the verifying key, here are checksums. Generate a proof yourself and check."*
+
+## Release contents
+
+Attach these artifacts to the Release:
+
+| File | Purpose | Source |
+|---|---|---|
+| `guess.circom` | Human-readable circuit source | `circuits/guess.circom` at the release tag |
+| `guess.r1cs` | Rank-1 constraint system, machine-readable | `build/v2/guess.r1cs` |
+| `guess.wasm` | Witness generator | `build/v2/guess.wasm` |
+| `guess_final.zkey` | Proving key post-ceremony | `build/v2/guess_final.zkey` |
+| `verification_key.json` | Public verifying key | `build/v2/verification_key.json` |
+| `GuessVerifier.sol` | Generated Solidity verifier (same file deployed on-chain) | `build/v2/Groth16Verifier.sol` |
+| `ceremony/` | Contribution transcripts | one file per contributor |
+| `MANIFEST.sha256` | SHA-256 of every other file in the release | generated at packaging time |
+
+## Generating MANIFEST.sha256
+
+```bash
+cd release-staging/
+sha256sum guess.circom guess.r1cs guess.wasm guess_final.zkey verification_key.json GuessVerifier.sol > MANIFEST.sha256
+```
+
+## Cross-linking
+
+- `zk-guess-contracts/src/GuessGame.sol` NatSpec gets `@custom:circuit-repo https://github.com/chainhackers/zk-guess-circuits/releases/tag/v2.0.0`
+- `zk-guess-contracts/README.md` links to the Release from its "Verifier" section
+- `SECURITY.md` references the release URL and MANIFEST checksum for the `GuessVerifier.sol` that's deployed
+- Project homepage (`zk-guess.chainhackers.xyz`) links to the release
+
+## Release body (markdown)
+
+Something like:
+
+> # zk-guess circuits v2.0.0
+>
+> New circuit with: puzzleId binding, guess range-check, domain-separated commitment, [guesser binding — if shipped].
+>
+> **Trusted setup**: phase-2 ceremony with 3 contributors + drand beacon. See `ceremony/` in this release for per-contributor transcripts and entropy attestations.
+>
+> **On-chain verifier**: `chainhackers/zk-guess-contracts` v2 uses the `GuessVerifier.sol` in this release verbatim. SHA-256 in MANIFEST.sha256 matches the deployed bytecode's source.
+>
+> **Reproducibility**: `snarkjs groth16 setup guess.r1cs <ptau> guess_final.zkey` followed by the ceremony replay from the contribution transcripts should land on the same `guess_final.zkey` hash.
+>
+> **License**: (same as repo)
+
+## Tests / verification
+
+- `sha256sum -c MANIFEST.sha256` passes inside the release archive.
+- SHA-256 of `GuessVerifier.sol` matches the source pushed to `zk-guess-contracts/src/generated/GuessVerifier.sol` at the v2 deploy commit.
+- A fresh clone of the release can generate a valid proof against the deployed verifier.
+
+## Acceptance
+
+- Release tagged `v2.0.0`, body written, all 7 assets attached.
+- MANIFEST.sha256 committed as a release artifact.
+- `@custom:circuit-repo` NatSpec pointing to this release lands in the contract.
+- Release URL included in the Blockaid `verifiedProject` submission.

--- a/tasks/range-check-guess.md
+++ b/tasks/range-check-guess.md
@@ -1,0 +1,42 @@
+# Range-check the guess input
+
+Part of the `v2` circuit redesign. Sibling plan: `zk-guess-contracts/docs/superpowers/specs/2026-04-23-clean-redeploy-antimixer-design.md`.
+
+## Goal
+
+Constrain `1 <= guess <= maxNumber` inside the circuit, symmetric with the existing constraints on `number`. Today only `number` and `maxNumber` are range-checked; `guess` is implicitly trusted to be within range because an honest frontend submits in-range guesses and the contract doesn't game-logically care whether an out-of-range guess is correct or not (it never will be since `guess == number` is the only truth condition and `number` is in range).
+
+This is a well-formedness guarantee at the proof layer rather than relying on the UI. It's also additional semantic distance from mixer-shape circuits (which typically do *not* range-check user-supplied values since their values are arbitrary field elements).
+
+## Changes
+
+In `circuits/guess.circom`, alongside the existing range checks on `number`:
+
+```circom
+// Check guess >= 1
+component guessGeq1 = GreaterEqThan(16);
+guessGeq1.in[0] <== guess;
+guessGeq1.in[1] <== 1;
+guessGeq1.out === 1;
+
+// Check guess <= maxNumber
+component guessLeqMax = LessEqThan(16);
+guessLeqMax.in[0] <== guess;
+guessLeqMax.in[1] <== maxNumber;
+guessLeqMax.out === 1;
+```
+
+No contract-side change (the contract already relies on proof validity).
+
+## Tests
+
+- **Positive**: `guess = 42`, `maxNumber = 100` → proof generates and verifies.
+- **Negative: below range**: `guess = 0`, `maxNumber = 100` → proof generation fails (constraint violation in witness).
+- **Negative: above range**: `guess = 101`, `maxNumber = 100` → proof generation fails.
+- **Edge**: `guess = 1` and `guess = maxNumber` both succeed.
+
+## Acceptance
+
+- Circom compilation succeeds; constraint count grows by ~64 (two 16-bit `Num2Bits`-based comparators).
+- Test suite covers positive, two negatives, and edges.
+- Generating a proof with out-of-range `guess` is impossible from the frontend — snarkjs errors with "Unsatisfied constraint".

--- a/tasks/trusted-setup-v2.md
+++ b/tasks/trusted-setup-v2.md
@@ -1,0 +1,72 @@
+# Trusted-setup v2 (phase-2 ceremony)
+
+Part of the `v2` circuit redesign. Sibling plan: `zk-guess-contracts/docs/superpowers/specs/2026-04-23-clean-redeploy-antimixer-design.md`.
+
+## Goal
+
+Run a fresh phase-2 contribution ceremony for the v2 circuit. The resulting `.zkey` and `verification_key.json` are what the new `GuessVerifier.sol` is generated from. Even if the circuit changes were zero, the new ceremony produces an entirely different verifier contract (different `IC[]`, different α/β/γ/δ constants, different bytecode) — which by itself breaks any bytecode-similarity cluster the old verifier was sitting in.
+
+Because we *are* changing the circuit (puzzleId binding + guess range + domain-separated commitment ± guesser binding), the ceremony runs against the new R1CS.
+
+## Prerequisites
+
+- v2 circuit is final: `bind-puzzle-id.md`, `range-check-guess.md`, `domain-separate-commitment.md` tasks merged (and `bind-guesser.md` decided one way or another).
+- Phase-1 `.ptau` file: reuse the existing `powersOfTau28_hez_final_14.ptau` (or bump to `_15` if the circuit grew past 2^14 constraints). Phase 1 is universal; no need to redo.
+
+## Ceremony procedure
+
+1. Compile the v2 circuit:
+   ```bash
+   circom circuits/guess.circom --r1cs --wasm --sym -o build/v2/
+   ```
+
+2. Groth16 phase-2 setup from phase-1 ptau:
+   ```bash
+   snarkjs groth16 setup build/v2/guess.r1cs <path-to-ptau> build/v2/guess_0000.zkey
+   ```
+
+3. **Multiple independent contributions.** Minimum 3 contributors; more is better. Each runs:
+   ```bash
+   snarkjs zkey contribute build/v2/guess_NNNN.zkey build/v2/guess_MMMM.zkey \
+     --name="contributor-<handle>" -e="<entropy-source-notes>"
+   ```
+   Each contributor should:
+   - Use a fresh machine or one they trust.
+   - Use a high-entropy string (system RNG + a user-typed passphrase + a live news headline works).
+   - Publish a SHA-256 attestation of their output `.zkey` on a public channel (Farcaster, Twitter, GitHub issue) with their contribution index and a signed message from their known identity.
+
+4. Apply a random beacon at the end:
+   ```bash
+   snarkjs zkey beacon build/v2/guess_NNNN.zkey build/v2/guess_final.zkey \
+     <32-byte-hex-from-drand-or-bitcoin-block-hash> 10 \
+     -n="v2 final beacon"
+   ```
+   Document the beacon source (e.g., Bitcoin block `N` hash on date `D`) so it can be audited.
+
+5. Export verification key and Solidity verifier:
+   ```bash
+   snarkjs zkey export verificationkey build/v2/guess_final.zkey build/v2/verification_key.json
+   snarkjs zkey export solidityverifier build/v2/guess_final.zkey build/v2/Groth16Verifier.sol
+   ```
+
+6. Copy artifacts into their consumers:
+   - `build/v2/verification_key.json` → commit to circuits repo under `generated/v2/`
+   - `build/v2/Groth16Verifier.sol` → copy to `zk-guess-contracts/src/generated/GuessVerifier.sol` (rename contract if needed; current `bun run copy-to-contracts` script in circuits repo handles this).
+
+## Trust assumptions
+
+The ceremony is secure as long as **at least one** contributor destroys their entropy (standard phase-2 property). Document this assumption in `SECURITY.md` and the Blockaid submission.
+
+## Tests
+
+- **Consistency**: `snarkjs groth16 prove` with the final `.zkey` produces a proof; `snarkjs groth16 verify` with the exported `verification_key.json` accepts it.
+- **Cross-check**: generate a proof, submit to a local Anvil instance with the generated `GuessVerifier.sol` deployed; `verifyProof` returns `true`.
+- **Attestation check**: each contributor's claimed transcript hash matches the actual zkey file's SHA-256.
+
+## Acceptance
+
+- ≥3 independent contributions + 1 beacon.
+- Final `.zkey` + `verification_key.json` committed to circuits repo.
+- Generated `GuessVerifier.sol` bytecode-diffs from v1 (sanity: contract size is similar but every constant differs).
+- Contribution attestations published on GitHub as a ceremony transcript (one file per contributor).
+- Ready for artifact release (next task: `publish-artifacts-release.md`).

--- a/test/guess.test.ts
+++ b/test/guess.test.ts
@@ -235,4 +235,40 @@ describe("GuessNumber Circuit", () => {
     expect(publicSignals[2]).toBe("42"); // guess
     expect(publicSignals[3]).toBe("100"); // maxNumber
   });
+
+  it("should enforce guess >= 1", async () => {
+    // guess = 0 is below range
+    await expect(generateProof(
+      { number: "42", salt: "12345", guess: "0", maxNumber: "100" },
+      circuitPaths.wasmPath,
+      circuitPaths.zkeyPath
+    )).rejects.toThrow();
+
+    // guess = 1 (edge) succeeds
+    const { publicSignals } = await generateProof(
+      { number: "42", salt: "12345", guess: "1", maxNumber: "100" },
+      circuitPaths.wasmPath,
+      circuitPaths.zkeyPath
+    );
+    expect(publicSignals[1]).toBe("0"); // wrong guess, but in-range
+    expect(publicSignals[2]).toBe("1");
+  });
+
+  it("should enforce guess <= maxNumber", async () => {
+    // guess = 101 exceeds maxNumber = 100
+    await expect(generateProof(
+      { number: "42", salt: "12345", guess: "101", maxNumber: "100" },
+      circuitPaths.wasmPath,
+      circuitPaths.zkeyPath
+    )).rejects.toThrow();
+
+    // guess = maxNumber (edge) succeeds
+    const { publicSignals } = await generateProof(
+      { number: "42", salt: "12345", guess: "100", maxNumber: "100" },
+      circuitPaths.wasmPath,
+      circuitPaths.zkeyPath
+    );
+    expect(publicSignals[1]).toBe("0"); // 100 != 42
+    expect(publicSignals[2]).toBe("100");
+  });
 });

--- a/test/guess.test.ts
+++ b/test/guess.test.ts
@@ -1,13 +1,10 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { generateProof, verifyProof, calculateCommitment, calculateCommitmentV1, getCircuitPaths } from "./utils";
+import { generateProof, verifyProof, calculateCommitment, poseidonHash, getCircuitPaths } from "./utils";
 import type { CircuitInputs } from "./utils";
-import { buildPoseidon } from "circomlibjs";
-import { DOMAIN_TAG } from "../src/constants";
+import { ALICE, BOB, DOMAIN_TAG } from "../src/constants";
 
-// Test addresses as decimal uint160 strings. Derived from hex literals at
-// module load so the decimal can never drift from the address.
-const ALICE = BigInt("0x1234567890123456789012345678901234567890").toString();
-const BOB = BigInt("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").toString();
+// Fields every test shares unless a specific case overrides one via spread.
+const DEFAULTS = { maxNumber: "100", puzzleId: "7", guesser: ALICE } as const;
 
 describe("GuessNumber Circuit", () => {
   let circuitPaths: ReturnType<typeof getCircuitPaths>;
@@ -17,212 +14,110 @@ describe("GuessNumber Circuit", () => {
   });
 
   it("should generate correct commitment", async () => {
-    const inputs: CircuitInputs = {
-      number: "42",
-      salt: "12345",
-      guess: "50",
-      maxNumber: "100", puzzleId: "7", guesser: ALICE
-    };
+    const inputs: CircuitInputs = { ...DEFAULTS, number: "42", salt: "12345", guess: "50" };
 
-    const { publicSignals } = await generateProof(
-      inputs,
-      circuitPaths.wasmPath,
-      circuitPaths.zkeyPath
-    );
+    const { publicSignals } = await generateProof(inputs, circuitPaths.wasmPath, circuitPaths.zkeyPath);
 
-    // publicSignals[0] is commitment, publicSignals[1] is isCorrect
-    const expectedCommitment = await calculateCommitment(42, 12345);
-    expect(publicSignals[0]).toBe(expectedCommitment);
-
-    // Check isCorrect is 0 (wrong guess)
+    expect(publicSignals[0]).toBe(await calculateCommitment(42, 12345));
     expect(publicSignals[1]).toBe("0");
   });
 
   it("should return isCorrect=1 for correct guess", async () => {
-    const inputs: CircuitInputs = {
-      number: "42",
-      salt: "12345",
-      guess: "42",
-      maxNumber: "100", puzzleId: "7", guesser: ALICE
-    };
+    const inputs: CircuitInputs = { ...DEFAULTS, number: "42", salt: "12345", guess: "42" };
 
-    const { publicSignals } = await generateProof(
-      inputs,
-      circuitPaths.wasmPath,
-      circuitPaths.zkeyPath
-    );
+    const { publicSignals } = await generateProof(inputs, circuitPaths.wasmPath, circuitPaths.zkeyPath);
 
-    // Check isCorrect is 1 (correct guess)
     expect(publicSignals[1]).toBe("1");
-
-    // Commitment should still be the same
-    const expectedCommitment = await calculateCommitment(42, 12345);
-    expect(publicSignals[0]).toBe(expectedCommitment);
+    expect(publicSignals[0]).toBe(await calculateCommitment(42, 12345));
   });
 
   it("should generate valid proofs", async () => {
-    const inputs: CircuitInputs = {
-      number: "42",
-      salt: "12345",
-      guess: "42",
-      maxNumber: "100", puzzleId: "7", guesser: ALICE
-    };
+    const inputs: CircuitInputs = { ...DEFAULTS, number: "42", salt: "12345", guess: "42" };
 
-    const { proof, publicSignals } = await generateProof(
-      inputs,
-      circuitPaths.wasmPath,
-      circuitPaths.zkeyPath
-    );
+    const { proof, publicSignals } = await generateProof(inputs, circuitPaths.wasmPath, circuitPaths.zkeyPath);
 
-    const isValid = await verifyProof(
-      proof,
-      publicSignals,
-      circuitPaths.vKeyPath
-    );
-
-    expect(isValid).toBe(true);
+    expect(await verifyProof(proof, publicSignals, circuitPaths.vKeyPath)).toBe(true);
   });
 
   it("should produce different commitments for different salts", async () => {
-    const inputs1: CircuitInputs = {
-      number: "42",
-      salt: "12345",
-      guess: "42",
-      maxNumber: "100", puzzleId: "7", guesser: ALICE
-    };
-
-    const inputs2: CircuitInputs = {
-      number: "42",
-      salt: "54321",
-      guess: "42",
-      maxNumber: "100", puzzleId: "7", guesser: ALICE
-    };
-
-    const { publicSignals: signals1 } = await generateProof(
-      inputs1,
+    const { publicSignals: a } = await generateProof(
+      { ...DEFAULTS, number: "42", salt: "12345", guess: "42" },
+      circuitPaths.wasmPath,
+      circuitPaths.zkeyPath
+    );
+    const { publicSignals: b } = await generateProof(
+      { ...DEFAULTS, number: "42", salt: "54321", guess: "42" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
 
-    const { publicSignals: signals2 } = await generateProof(
-      inputs2,
-      circuitPaths.wasmPath,
-      circuitPaths.zkeyPath
-    );
-
-    // Same number, different salt = different commitment
-    expect(signals1[0]).not.toBe(signals2[0]);
-
-    // Both should be correct guesses
-    expect(signals1[1]).toBe("1");
-    expect(signals2[1]).toBe("1");
+    expect(a[0]).not.toBe(b[0]);
+    expect(a[1]).toBe("1");
+    expect(b[1]).toBe("1");
   });
 
   it("should enforce number >= 1", async () => {
-    // Test number = 0 (should fail)
     await expect(generateProof(
-      {
-        number: "0",
-        salt: "12345",
-        guess: "0",
-        maxNumber: "100", puzzleId: "7", guesser: ALICE
-      },
+      { ...DEFAULTS, number: "0", salt: "12345", guess: "0" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     )).rejects.toThrow();
 
-    // Test number = 1 (should pass)
-    const { publicSignals: signals1 } = await generateProof(
-      {
-        number: "1",
-        salt: "12345",
-        guess: "1",
-        maxNumber: "100", puzzleId: "7", guesser: ALICE
-      },
+    const { publicSignals } = await generateProof(
+      { ...DEFAULTS, number: "1", salt: "12345", guess: "1" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
-    expect(signals1[1]).toBe("1"); // Correct guess
+    expect(publicSignals[1]).toBe("1");
   });
 
   it("should enforce number <= maxNumber", async () => {
-    // Test number > maxNumber (should fail)
     await expect(generateProof(
-      {
-        number: "101",
-        salt: "12345",
-        guess: "101",
-        maxNumber: "100", puzzleId: "7", guesser: ALICE
-      },
+      { ...DEFAULTS, number: "101", salt: "12345", guess: "101" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     )).rejects.toThrow();
 
-    // Test number = maxNumber (should pass)
     const { publicSignals } = await generateProof(
-      {
-        number: "100",
-        salt: "12345",
-        guess: "100",
-        maxNumber: "100", puzzleId: "7", guesser: ALICE
-      },
+      { ...DEFAULTS, number: "100", salt: "12345", guess: "100" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
-    expect(publicSignals[1]).toBe("1"); // Correct guess
+    expect(publicSignals[1]).toBe("1");
   });
 
   it("should enforce maxNumber <= 65535", async () => {
-    // Test maxNumber > 65535 (should fail)
     await expect(generateProof(
-      {
-        number: "100",
-        salt: "12345",
-        guess: "100",
-        maxNumber: "65536", puzzleId: "7", guesser: ALICE
-      },
+      { ...DEFAULTS, number: "100", salt: "12345", guess: "100", maxNumber: "65536" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     )).rejects.toThrow();
 
-    // Test maxNumber = 65535 (should pass)
     const { publicSignals } = await generateProof(
-      {
-        number: "65535",
-        salt: "12345",
-        guess: "65535",
-        maxNumber: "65535", puzzleId: "7", guesser: ALICE
-      },
+      { ...DEFAULTS, number: "65535", salt: "12345", guess: "65535", maxNumber: "65535" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
-    expect(publicSignals[1]).toBe("1"); // Correct guess
+    expect(publicSignals[1]).toBe("1");
   });
 
   it("should enforce maxNumber >= 1", async () => {
-    // Test maxNumber = 0 (should fail)
     await expect(generateProof(
-      {
-        number: "1",
-        salt: "12345",
-        guess: "1",
-        maxNumber: "0", puzzleId: "7", guesser: ALICE
-      },
+      { ...DEFAULTS, number: "1", salt: "12345", guess: "1", maxNumber: "0" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     )).rejects.toThrow();
   });
 
-  // Proofs must be distinguishable by public signals so the contract knows which proof is for which guess
+  // Public signals must differ per guess so the contract can tell proofs apart.
   it("should produce different public signals for different guesses", async () => {
     const proofA = await generateProof(
-      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7", guesser: ALICE },
+      { ...DEFAULTS, number: "42", salt: "12345", guess: "42" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
-
     const proofB = await generateProof(
-      { number: "42", salt: "12345", guess: "99", maxNumber: "100", puzzleId: "7", guesser: ALICE },
+      { ...DEFAULTS, number: "42", salt: "12345", guess: "99" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
@@ -233,54 +128,48 @@ describe("GuessNumber Circuit", () => {
 
   it("should expose maxNumber, puzzleId, and guesser in public signals", async () => {
     const { publicSignals } = await generateProof(
-      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7", guesser: ALICE },
+      { ...DEFAULTS, number: "42", salt: "12345", guess: "42" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
 
-    // Public signals: [commitment, isCorrect, guess, maxNumber, puzzleId, guesser]
-    expect(publicSignals[2]).toBe("42"); // guess
-    expect(publicSignals[3]).toBe("100"); // maxNumber
-    expect(publicSignals[4]).toBe("7"); // puzzleId
-    expect(publicSignals[5]).toBe(ALICE); // guesser
+    // [commitment, isCorrect, guess, maxNumber, puzzleId, guesser]
+    expect(publicSignals[2]).toBe("42");
+    expect(publicSignals[3]).toBe(DEFAULTS.maxNumber);
+    expect(publicSignals[4]).toBe(DEFAULTS.puzzleId);
+    expect(publicSignals[5]).toBe(DEFAULTS.guesser);
   });
 
   it("should domain-separate commitments from v1 (Poseidon(2))", async () => {
     const { publicSignals } = await generateProof(
-      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7", guesser: ALICE },
+      { ...DEFAULTS, number: "42", salt: "12345", guess: "42" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
 
     const v2 = await calculateCommitment(42, 12345);
-    const v1 = await calculateCommitmentV1(42, 12345);
+    const v1 = await poseidonHash([42, 12345]);
 
-    // Circuit produces the v2 commitment
     expect(publicSignals[0]).toBe(v2);
-    // v1 commitment for the same (number, salt) is different from v2
     expect(v1).not.toBe(v2);
   });
 
   it("should produce different commitments under different DOMAIN_TAGs", async () => {
-    const poseidon = await buildPoseidon();
-    const F = poseidon.F;
-    const withV2Tag = F.toString(poseidon([DOMAIN_TAG, 42n, 12345n]));
-    const withV3Tag = F.toString(poseidon([DOMAIN_TAG + 1n, 42n, 12345n]));
+    const withV2Tag = await poseidonHash([DOMAIN_TAG, 42n, 12345n]);
+    const withV3Tag = await poseidonHash([DOMAIN_TAG + 1n, 42n, 12345n]);
 
     expect(withV2Tag).not.toBe(withV3Tag);
   });
 
   it("should reject a proof rebound to a different puzzleId", async () => {
     const { proof, publicSignals } = await generateProof(
-      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7", guesser: ALICE },
+      { ...DEFAULTS, number: "42", salt: "12345", guess: "42" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
 
-    // Baseline: the original public signals verify
     expect(await verifyProof(proof, publicSignals, circuitPaths.vKeyPath)).toBe(true);
 
-    // Tamper: swap puzzleId 7 -> 8 in the public-signals array and re-verify
     const tampered = [...publicSignals];
     tampered[4] = "8";
     expect(await verifyProof(proof, tampered, circuitPaths.vKeyPath)).toBe(false);
@@ -288,52 +177,47 @@ describe("GuessNumber Circuit", () => {
 
   it("should reject a proof rebound to a different guesser (front-run defense)", async () => {
     const { proof, publicSignals } = await generateProof(
-      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7", guesser: ALICE },
+      { ...DEFAULTS, number: "42", salt: "12345", guess: "42" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
 
     expect(await verifyProof(proof, publicSignals, circuitPaths.vKeyPath)).toBe(true);
 
-    // Tamper: Bob tries to replay Alice's proof under his own address
     const tampered = [...publicSignals];
     tampered[5] = BOB;
     expect(await verifyProof(proof, tampered, circuitPaths.vKeyPath)).toBe(false);
   });
 
   it("should enforce guess >= 1", async () => {
-    // guess = 0 is below range
     await expect(generateProof(
-      { number: "42", salt: "12345", guess: "0", maxNumber: "100", puzzleId: "7", guesser: ALICE },
+      { ...DEFAULTS, number: "42", salt: "12345", guess: "0" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     )).rejects.toThrow();
 
-    // guess = 1 (edge) succeeds
     const { publicSignals } = await generateProof(
-      { number: "42", salt: "12345", guess: "1", maxNumber: "100", puzzleId: "7", guesser: ALICE },
+      { ...DEFAULTS, number: "42", salt: "12345", guess: "1" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
-    expect(publicSignals[1]).toBe("0"); // wrong guess, but in-range
+    expect(publicSignals[1]).toBe("0");
     expect(publicSignals[2]).toBe("1");
   });
 
   it("should enforce guess <= maxNumber", async () => {
-    // guess = 101 exceeds maxNumber = 100
     await expect(generateProof(
-      { number: "42", salt: "12345", guess: "101", maxNumber: "100", puzzleId: "7", guesser: ALICE },
+      { ...DEFAULTS, number: "42", salt: "12345", guess: "101" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     )).rejects.toThrow();
 
-    // guess = maxNumber (edge) succeeds
     const { publicSignals } = await generateProof(
-      { number: "42", salt: "12345", guess: "100", maxNumber: "100", puzzleId: "7", guesser: ALICE },
+      { ...DEFAULTS, number: "42", salt: "12345", guess: "100" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
-    expect(publicSignals[1]).toBe("0"); // 100 != 42
+    expect(publicSignals[1]).toBe("0");
     expect(publicSignals[2]).toBe("100");
   });
 });

--- a/test/guess.test.ts
+++ b/test/guess.test.ts
@@ -4,6 +4,12 @@ import type { CircuitInputs } from "./utils";
 import { buildPoseidon } from "circomlibjs";
 import { DOMAIN_TAG } from "../src/constants";
 
+// Test addresses as decimal uint160 strings.
+// ALICE = 0x1234567890123456789012345678901234567890
+// BOB   = 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+const ALICE = "104134845626036279338909600961366137424362805893520";
+const BOB = "974334424887268612135789888477522013103955028650";
+
 describe("GuessNumber Circuit", () => {
   let circuitPaths: ReturnType<typeof getCircuitPaths>;
 
@@ -16,7 +22,7 @@ describe("GuessNumber Circuit", () => {
       number: "42",
       salt: "12345",
       guess: "50",
-      maxNumber: "100", puzzleId: "7"
+      maxNumber: "100", puzzleId: "7", guesser: ALICE
     };
 
     const { publicSignals } = await generateProof(
@@ -38,7 +44,7 @@ describe("GuessNumber Circuit", () => {
       number: "42",
       salt: "12345",
       guess: "42",
-      maxNumber: "100", puzzleId: "7"
+      maxNumber: "100", puzzleId: "7", guesser: ALICE
     };
 
     const { publicSignals } = await generateProof(
@@ -60,7 +66,7 @@ describe("GuessNumber Circuit", () => {
       number: "42",
       salt: "12345",
       guess: "42",
-      maxNumber: "100", puzzleId: "7"
+      maxNumber: "100", puzzleId: "7", guesser: ALICE
     };
 
     const { proof, publicSignals } = await generateProof(
@@ -83,14 +89,14 @@ describe("GuessNumber Circuit", () => {
       number: "42",
       salt: "12345",
       guess: "42",
-      maxNumber: "100", puzzleId: "7"
+      maxNumber: "100", puzzleId: "7", guesser: ALICE
     };
 
     const inputs2: CircuitInputs = {
       number: "42",
       salt: "54321",
       guess: "42",
-      maxNumber: "100", puzzleId: "7"
+      maxNumber: "100", puzzleId: "7", guesser: ALICE
     };
 
     const { publicSignals: signals1 } = await generateProof(
@@ -120,7 +126,7 @@ describe("GuessNumber Circuit", () => {
         number: "0",
         salt: "12345",
         guess: "0",
-        maxNumber: "100", puzzleId: "7"
+        maxNumber: "100", puzzleId: "7", guesser: ALICE
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
@@ -132,7 +138,7 @@ describe("GuessNumber Circuit", () => {
         number: "1",
         salt: "12345",
         guess: "1",
-        maxNumber: "100", puzzleId: "7"
+        maxNumber: "100", puzzleId: "7", guesser: ALICE
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
@@ -147,7 +153,7 @@ describe("GuessNumber Circuit", () => {
         number: "101",
         salt: "12345",
         guess: "101",
-        maxNumber: "100", puzzleId: "7"
+        maxNumber: "100", puzzleId: "7", guesser: ALICE
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
@@ -159,7 +165,7 @@ describe("GuessNumber Circuit", () => {
         number: "100",
         salt: "12345",
         guess: "100",
-        maxNumber: "100", puzzleId: "7"
+        maxNumber: "100", puzzleId: "7", guesser: ALICE
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
@@ -174,7 +180,7 @@ describe("GuessNumber Circuit", () => {
         number: "100",
         salt: "12345",
         guess: "100",
-        maxNumber: "65536", puzzleId: "7"
+        maxNumber: "65536", puzzleId: "7", guesser: ALICE
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
@@ -186,7 +192,7 @@ describe("GuessNumber Circuit", () => {
         number: "65535",
         salt: "12345",
         guess: "65535",
-        maxNumber: "65535", puzzleId: "7"
+        maxNumber: "65535", puzzleId: "7", guesser: ALICE
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
@@ -201,7 +207,7 @@ describe("GuessNumber Circuit", () => {
         number: "1",
         salt: "12345",
         guess: "1",
-        maxNumber: "0", puzzleId: "7"
+        maxNumber: "0", puzzleId: "7", guesser: ALICE
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
@@ -211,13 +217,13 @@ describe("GuessNumber Circuit", () => {
   // Proofs must be distinguishable by public signals so the contract knows which proof is for which guess
   it("should produce different public signals for different guesses", async () => {
     const proofA = await generateProof(
-      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7" },
+      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7", guesser: ALICE },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
 
     const proofB = await generateProof(
-      { number: "42", salt: "12345", guess: "99", maxNumber: "100", puzzleId: "7" },
+      { number: "42", salt: "12345", guess: "99", maxNumber: "100", puzzleId: "7", guesser: ALICE },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
@@ -226,22 +232,23 @@ describe("GuessNumber Circuit", () => {
     expect(proofA.publicSignals).not.toEqual(proofB.publicSignals);
   });
 
-  it("should expose maxNumber and puzzleId in public signals", async () => {
+  it("should expose maxNumber, puzzleId, and guesser in public signals", async () => {
     const { publicSignals } = await generateProof(
-      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7" },
+      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7", guesser: ALICE },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
 
-    // Public signals: [commitment, isCorrect, guess, maxNumber, puzzleId]
+    // Public signals: [commitment, isCorrect, guess, maxNumber, puzzleId, guesser]
     expect(publicSignals[2]).toBe("42"); // guess
     expect(publicSignals[3]).toBe("100"); // maxNumber
     expect(publicSignals[4]).toBe("7"); // puzzleId
+    expect(publicSignals[5]).toBe(ALICE); // guesser
   });
 
   it("should domain-separate commitments from v1 (Poseidon(2))", async () => {
     const { publicSignals } = await generateProof(
-      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7" },
+      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7", guesser: ALICE },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
@@ -266,7 +273,7 @@ describe("GuessNumber Circuit", () => {
 
   it("should reject a proof rebound to a different puzzleId", async () => {
     const { proof, publicSignals } = await generateProof(
-      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7" },
+      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7", guesser: ALICE },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
@@ -280,17 +287,32 @@ describe("GuessNumber Circuit", () => {
     expect(await verifyProof(proof, tampered, circuitPaths.vKeyPath)).toBe(false);
   });
 
+  it("should reject a proof rebound to a different guesser (front-run defense)", async () => {
+    const { proof, publicSignals } = await generateProof(
+      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7", guesser: ALICE },
+      circuitPaths.wasmPath,
+      circuitPaths.zkeyPath
+    );
+
+    expect(await verifyProof(proof, publicSignals, circuitPaths.vKeyPath)).toBe(true);
+
+    // Tamper: Bob tries to replay Alice's proof under his own address
+    const tampered = [...publicSignals];
+    tampered[5] = BOB;
+    expect(await verifyProof(proof, tampered, circuitPaths.vKeyPath)).toBe(false);
+  });
+
   it("should enforce guess >= 1", async () => {
     // guess = 0 is below range
     await expect(generateProof(
-      { number: "42", salt: "12345", guess: "0", maxNumber: "100", puzzleId: "7" },
+      { number: "42", salt: "12345", guess: "0", maxNumber: "100", puzzleId: "7", guesser: ALICE },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     )).rejects.toThrow();
 
     // guess = 1 (edge) succeeds
     const { publicSignals } = await generateProof(
-      { number: "42", salt: "12345", guess: "1", maxNumber: "100", puzzleId: "7" },
+      { number: "42", salt: "12345", guess: "1", maxNumber: "100", puzzleId: "7", guesser: ALICE },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
@@ -301,14 +323,14 @@ describe("GuessNumber Circuit", () => {
   it("should enforce guess <= maxNumber", async () => {
     // guess = 101 exceeds maxNumber = 100
     await expect(generateProof(
-      { number: "42", salt: "12345", guess: "101", maxNumber: "100", puzzleId: "7" },
+      { number: "42", salt: "12345", guess: "101", maxNumber: "100", puzzleId: "7", guesser: ALICE },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     )).rejects.toThrow();
 
     // guess = maxNumber (edge) succeeds
     const { publicSignals } = await generateProof(
-      { number: "42", salt: "12345", guess: "100", maxNumber: "100", puzzleId: "7" },
+      { number: "42", salt: "12345", guess: "100", maxNumber: "100", puzzleId: "7", guesser: ALICE },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );

--- a/test/guess.test.ts
+++ b/test/guess.test.ts
@@ -14,7 +14,7 @@ describe("GuessNumber Circuit", () => {
       number: "42",
       salt: "12345",
       guess: "50",
-      maxNumber: "100"
+      maxNumber: "100", puzzleId: "7"
     };
 
     const { publicSignals } = await generateProof(
@@ -36,7 +36,7 @@ describe("GuessNumber Circuit", () => {
       number: "42",
       salt: "12345",
       guess: "42",
-      maxNumber: "100"
+      maxNumber: "100", puzzleId: "7"
     };
 
     const { publicSignals } = await generateProof(
@@ -58,7 +58,7 @@ describe("GuessNumber Circuit", () => {
       number: "42",
       salt: "12345",
       guess: "42",
-      maxNumber: "100"
+      maxNumber: "100", puzzleId: "7"
     };
 
     const { proof, publicSignals } = await generateProof(
@@ -81,14 +81,14 @@ describe("GuessNumber Circuit", () => {
       number: "42",
       salt: "12345",
       guess: "42",
-      maxNumber: "100"
+      maxNumber: "100", puzzleId: "7"
     };
 
     const inputs2: CircuitInputs = {
       number: "42",
       salt: "54321",
       guess: "42",
-      maxNumber: "100"
+      maxNumber: "100", puzzleId: "7"
     };
 
     const { publicSignals: signals1 } = await generateProof(
@@ -118,7 +118,7 @@ describe("GuessNumber Circuit", () => {
         number: "0",
         salt: "12345",
         guess: "0",
-        maxNumber: "100"
+        maxNumber: "100", puzzleId: "7"
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
@@ -130,7 +130,7 @@ describe("GuessNumber Circuit", () => {
         number: "1",
         salt: "12345",
         guess: "1",
-        maxNumber: "100"
+        maxNumber: "100", puzzleId: "7"
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
@@ -145,7 +145,7 @@ describe("GuessNumber Circuit", () => {
         number: "101",
         salt: "12345",
         guess: "101",
-        maxNumber: "100"
+        maxNumber: "100", puzzleId: "7"
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
@@ -157,7 +157,7 @@ describe("GuessNumber Circuit", () => {
         number: "100",
         salt: "12345",
         guess: "100",
-        maxNumber: "100"
+        maxNumber: "100", puzzleId: "7"
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
@@ -172,7 +172,7 @@ describe("GuessNumber Circuit", () => {
         number: "100",
         salt: "12345",
         guess: "100",
-        maxNumber: "65536"
+        maxNumber: "65536", puzzleId: "7"
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
@@ -184,7 +184,7 @@ describe("GuessNumber Circuit", () => {
         number: "65535",
         salt: "12345",
         guess: "65535",
-        maxNumber: "65535"
+        maxNumber: "65535", puzzleId: "7"
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
@@ -199,7 +199,7 @@ describe("GuessNumber Circuit", () => {
         number: "1",
         salt: "12345",
         guess: "1",
-        maxNumber: "0"
+        maxNumber: "0", puzzleId: "7"
       },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
@@ -209,13 +209,13 @@ describe("GuessNumber Circuit", () => {
   // Proofs must be distinguishable by public signals so the contract knows which proof is for which guess
   it("should produce different public signals for different guesses", async () => {
     const proofA = await generateProof(
-      { number: "42", salt: "12345", guess: "42", maxNumber: "100" },
+      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
 
     const proofB = await generateProof(
-      { number: "42", salt: "12345", guess: "99", maxNumber: "100" },
+      { number: "42", salt: "12345", guess: "99", maxNumber: "100", puzzleId: "7" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
@@ -224,29 +224,46 @@ describe("GuessNumber Circuit", () => {
     expect(proofA.publicSignals).not.toEqual(proofB.publicSignals);
   });
 
-  it("should include maxNumber in public signals", async () => {
+  it("should expose maxNumber and puzzleId in public signals", async () => {
     const { publicSignals } = await generateProof(
-      { number: "42", salt: "12345", guess: "42", maxNumber: "100" },
+      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
 
-    // Public signals: [commitment, isCorrect, guess, maxNumber]
+    // Public signals: [commitment, isCorrect, guess, maxNumber, puzzleId]
     expect(publicSignals[2]).toBe("42"); // guess
     expect(publicSignals[3]).toBe("100"); // maxNumber
+    expect(publicSignals[4]).toBe("7"); // puzzleId
+  });
+
+  it("should reject a proof rebound to a different puzzleId", async () => {
+    const { proof, publicSignals } = await generateProof(
+      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7" },
+      circuitPaths.wasmPath,
+      circuitPaths.zkeyPath
+    );
+
+    // Baseline: the original public signals verify
+    expect(await verifyProof(proof, publicSignals, circuitPaths.vKeyPath)).toBe(true);
+
+    // Tamper: swap puzzleId 7 -> 8 in the public-signals array and re-verify
+    const tampered = [...publicSignals];
+    tampered[4] = "8";
+    expect(await verifyProof(proof, tampered, circuitPaths.vKeyPath)).toBe(false);
   });
 
   it("should enforce guess >= 1", async () => {
     // guess = 0 is below range
     await expect(generateProof(
-      { number: "42", salt: "12345", guess: "0", maxNumber: "100" },
+      { number: "42", salt: "12345", guess: "0", maxNumber: "100", puzzleId: "7" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     )).rejects.toThrow();
 
     // guess = 1 (edge) succeeds
     const { publicSignals } = await generateProof(
-      { number: "42", salt: "12345", guess: "1", maxNumber: "100" },
+      { number: "42", salt: "12345", guess: "1", maxNumber: "100", puzzleId: "7" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );
@@ -257,14 +274,14 @@ describe("GuessNumber Circuit", () => {
   it("should enforce guess <= maxNumber", async () => {
     // guess = 101 exceeds maxNumber = 100
     await expect(generateProof(
-      { number: "42", salt: "12345", guess: "101", maxNumber: "100" },
+      { number: "42", salt: "12345", guess: "101", maxNumber: "100", puzzleId: "7" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     )).rejects.toThrow();
 
     // guess = maxNumber (edge) succeeds
     const { publicSignals } = await generateProof(
-      { number: "42", salt: "12345", guess: "100", maxNumber: "100" },
+      { number: "42", salt: "12345", guess: "100", maxNumber: "100", puzzleId: "7" },
       circuitPaths.wasmPath,
       circuitPaths.zkeyPath
     );

--- a/test/guess.test.ts
+++ b/test/guess.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { generateProof, verifyProof, calculateCommitment, getCircuitPaths } from "./utils";
+import { generateProof, verifyProof, calculateCommitment, calculateCommitmentV1, getCircuitPaths } from "./utils";
 import type { CircuitInputs } from "./utils";
+import { buildPoseidon } from "circomlibjs";
+import { DOMAIN_TAG } from "../src/constants";
 
 describe("GuessNumber Circuit", () => {
   let circuitPaths: ReturnType<typeof getCircuitPaths>;
@@ -235,6 +237,31 @@ describe("GuessNumber Circuit", () => {
     expect(publicSignals[2]).toBe("42"); // guess
     expect(publicSignals[3]).toBe("100"); // maxNumber
     expect(publicSignals[4]).toBe("7"); // puzzleId
+  });
+
+  it("should domain-separate commitments from v1 (Poseidon(2))", async () => {
+    const { publicSignals } = await generateProof(
+      { number: "42", salt: "12345", guess: "42", maxNumber: "100", puzzleId: "7" },
+      circuitPaths.wasmPath,
+      circuitPaths.zkeyPath
+    );
+
+    const v2 = await calculateCommitment(42, 12345);
+    const v1 = await calculateCommitmentV1(42, 12345);
+
+    // Circuit produces the v2 commitment
+    expect(publicSignals[0]).toBe(v2);
+    // v1 commitment for the same (number, salt) is different from v2
+    expect(v1).not.toBe(v2);
+  });
+
+  it("should produce different commitments under different DOMAIN_TAGs", async () => {
+    const poseidon = await buildPoseidon();
+    const F = poseidon.F;
+    const withV2Tag = F.toString(poseidon([DOMAIN_TAG, 42n, 12345n]));
+    const withV3Tag = F.toString(poseidon([DOMAIN_TAG + 1n, 42n, 12345n]));
+
+    expect(withV2Tag).not.toBe(withV3Tag);
   });
 
   it("should reject a proof rebound to a different puzzleId", async () => {

--- a/test/guess.test.ts
+++ b/test/guess.test.ts
@@ -4,11 +4,10 @@ import type { CircuitInputs } from "./utils";
 import { buildPoseidon } from "circomlibjs";
 import { DOMAIN_TAG } from "../src/constants";
 
-// Test addresses as decimal uint160 strings.
-// ALICE = 0x1234567890123456789012345678901234567890
-// BOB   = 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-const ALICE = "104134845626036279338909600961366137424362805893520";
-const BOB = "974334424887268612135789888477522013103955028650";
+// Test addresses as decimal uint160 strings. Derived from hex literals at
+// module load so the decimal can never drift from the address.
+const ALICE = BigInt("0x1234567890123456789012345678901234567890").toString();
+const BOB = BigInt("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").toString();
 
 describe("GuessNumber Circuit", () => {
   let circuitPaths: ReturnType<typeof getCircuitPaths>;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -46,20 +46,18 @@ export async function verifyProof(
   return await groth16.verify(vKey, publicSignals, proof);
 }
 
-export async function calculateCommitment(number: number | bigint, salt: number | bigint): Promise<string> {
-  const poseidon = await buildPoseidon();
-  const F = poseidon.F;
-  const hash = poseidon([DOMAIN_TAG, number, salt]);
-  return F.toString(hash);
+// Cache the Poseidon instance — WASM init is ~200ms and this gets called many times
+// across the test suite.
+let poseidonPromise: ReturnType<typeof buildPoseidon> | null = null;
+const getPoseidon = () => (poseidonPromise ??= buildPoseidon());
+
+export async function poseidonHash(inputs: (number | bigint)[]): Promise<string> {
+  const poseidon = await getPoseidon();
+  return poseidon.F.toString(poseidon(inputs));
 }
 
-// v1 commitment (Poseidon(2) without domain separation). Retained for regression tests
-// that assert v1 commitments cannot be reused under the v2 circuit.
-export async function calculateCommitmentV1(number: number | bigint, salt: number | bigint): Promise<string> {
-  const poseidon = await buildPoseidon();
-  const F = poseidon.F;
-  const hash = poseidon([number, salt]);
-  return F.toString(hash);
+export async function calculateCommitment(number: number | bigint, salt: number | bigint): Promise<string> {
+  return poseidonHash([DOMAIN_TAG, number, salt]);
 }
 
 export function getCircuitPaths(circuitName: string) {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -12,6 +12,7 @@ export interface CircuitInputs {
   guess: string;
   maxNumber: string;
   puzzleId: string;
+  guesser: string; // uint160 (Ethereum address as decimal bigint string)
 }
 
 export interface ProofResult {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -10,6 +10,7 @@ export interface CircuitInputs {
   salt: string;
   guess: string;
   maxNumber: string;
+  puzzleId: string;
 }
 
 export interface ProofResult {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -2,6 +2,7 @@ import { groth16 } from "snarkjs";
 import { buildPoseidon } from "circomlibjs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { DOMAIN_TAG } from "../src/constants";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -44,7 +45,16 @@ export async function verifyProof(
   return await groth16.verify(vKey, publicSignals, proof);
 }
 
-export async function calculateCommitment(number: number, salt: number): Promise<string> {
+export async function calculateCommitment(number: number | bigint, salt: number | bigint): Promise<string> {
+  const poseidon = await buildPoseidon();
+  const F = poseidon.F;
+  const hash = poseidon([DOMAIN_TAG, number, salt]);
+  return F.toString(hash);
+}
+
+// v1 commitment (Poseidon(2) without domain separation). Retained for regression tests
+// that assert v1 commitments cannot be reused under the v2 circuit.
+export async function calculateCommitmentV1(number: number | bigint, salt: number | bigint): Promise<string> {
   const poseidon = await buildPoseidon();
   const F = poseidon.F;
   const hash = poseidon([number, salt]);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -54,8 +54,8 @@ export function getCircuitPaths(circuitName: string) {
   const base = path.join(__dirname, "..", "generated");
   return {
     wasmPath: path.join(base, `${circuitName}_js`, `${circuitName}.wasm`),
-    zkeyPath: path.join(base, `${circuitName}_final.zkey`),
-    vKeyPath: path.join(base, `${circuitName}_verification_key.json`),
+    zkeyPath: path.join(base, `${circuitName}_dev.zkey`),
+    vKeyPath: path.join(base, `${circuitName}_dev_verification_key.json`),
     r1csPath: path.join(base, `${circuitName}.r1cs`),
   };
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -52,8 +52,17 @@ let poseidonPromise: ReturnType<typeof buildPoseidon> | null = null;
 const getPoseidon = () => (poseidonPromise ??= buildPoseidon());
 
 export async function poseidonHash(inputs: (number | bigint)[]): Promise<string> {
+  // Reject `number` inputs past 2^53-1 — circomlibjs would silently truncate
+  // the floating-point value before hashing, producing a wrong commitment.
+  const normalized = inputs.map((v) => {
+    if (typeof v === "bigint") return v;
+    if (!Number.isSafeInteger(v)) {
+      throw new TypeError(`poseidonHash: number inputs must be safe integers; got ${v}`);
+    }
+    return BigInt(v);
+  });
   const poseidon = await getPoseidon();
-  return poseidon.F.toString(poseidon(inputs));
+  return poseidon.F.toString(poseidon(normalized));
 }
 
 export async function calculateCommitment(number: number | bigint, salt: number | bigint): Promise<string> {


### PR DESCRIPTION
Implements the four circuit changes from issue #10's v2 anti-mixer roadmap, plus dev-vs-shipping artifact plumbing.

Branch is structured as one commit per task brief so each can be reviewed in isolation; tests pass at every commit.

## Circuit changes (`circuits/guess.circom`)

- **`puzzleId` (5th public input)** — bound via `puzzleIdSquared <== puzzleId * puzzleId`. Prevents a valid proof for puzzle A from being replayed on puzzle B even when both share the same commitment. Closes `tasks/bind-puzzle-id.md`.
- **`guesser` (6th public input)** — same idiom on a uint160 field element. Prevents a third party from front-running someone else's proof submission with their own `msg.sender`. Closes `tasks/bind-guesser.md`.
- **Guess range check** — `1 <= guess <= maxNumber` enforced in-circuit via two 16-bit comparators, symmetric with the existing constraints on `number`. Closes `tasks/range-check-guess.md`.
- **Domain-separated commitment** — `Poseidon([DOMAIN_TAG, number, salt])` where `DOMAIN_TAG = keccak256("zkguess.v2") mod p(BN254) = 6000605569458108169701754207643449997818461959397281845176039583157698733685`. v1 commitments cannot collide with v2 under any future composition. Closes `tasks/domain-separate-commitment.md`.

Final public signals (load-bearing across the contracts and frontend repos): `[commitment, isCorrect, guess, maxNumber, puzzleId, guesser]`.

## Dev-vs-shipping plumbing

- `scripts/setup.ts` → `scripts/setup-dev.ts`; output renamed `guess_final.zkey` → `guess_dev.zkey` (and vkey similarly). The `guess_final.zkey` filename is now reserved for the phase-2 ceremony output (tracked separately in `tasks/trusted-setup-v2.md`).
- `scripts/copy-artifacts.sh` now chains `bun run export-verifier` so `GuessVerifier.sol` can never drift from the zkey it was derived from. Both copy scripts write `BUILD_INFO.txt` (`BUILD=dev`, source SHA, timestamp) into the destination so consumer repos can tell at a glance.
- New shared module `src/constants.ts` exporting `DOMAIN_TAG`, `ALICE`, `BOB` so circuit, tests, and the frontend (eventually) read from one source.

## Tests

`test/guess.test.ts` covers every spec point: positive cases, range-violation negatives, edges, puzzleId and guesser rebind-attempts (tampered public signals → verification fails), v1-regression (Poseidon(2) commitment ≠ v2 commitment), and cross-DOMAIN_TAG distinctness. 16/16 passing. Test inputs use a `DEFAULTS` spread so non-default cases are visually obvious.

## Out of scope

- Trusted setup ceremony (`tasks/trusted-setup-v2.md`) — separate branch.
- GitHub Release v2.0.0 with `MANIFEST.sha256` (`tasks/publish-artifacts-release.md`) — separate branch.
- In-circuit 160-bit range constraint on `guesser` (and equivalent on `puzzleId`) — see #11.

## Consumer-side follow-ups

- `chainhackers/zk-guess-contracts`: update `GuessGame.respondToChallenge` to read `_pubSignals[4]` (puzzleId) and `_pubSignals[5]` (guesser) and revert with `InvalidPuzzleIdBinding()` / `InvalidGuesserBinding()`. Dev-build artifacts (`guess_dev.zkey` + `BUILD_INFO.txt`) already copied so contracts dev/test can proceed in parallel.
- `chainhackers/zk-guess` frontend: import `DOMAIN_TAG` from `src/constants.ts`, pass `puzzleId` and `guesser` as proof inputs, switch witness/vkey loader to the `_dev` filenames during dev (then to `_final` post-ceremony).

Closes #10 once contracts/frontend follow-ups land.